### PR TITLE
Add debug logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
+local/
 dintero-checkout-v2.zip

--- a/includes/class-dintero-adapter.php
+++ b/includes/class-dintero-adapter.php
@@ -114,7 +114,8 @@ class Dintero_Adapter {
 				)
 			)
 		);
-
+		$log = Dintero_Logger::format_log('unknown', 'access_token', 'Get access token', array(), $response, 200);
+		Dintero_Logger::log($log);
 		return isset( $response['access_token'] ) ? $response['access_token'] : false;
 	}
 
@@ -237,6 +238,11 @@ class Dintero_Adapter {
 			Dintero_Request_Builder::instance()->build( $request )
 		);
 
-		return $this->decode( wp_remote_retrieve_body( $response ) );
+		$response_json = $this->decode( wp_remote_retrieve_body( $response ) );
+		$code = wp_remote_retrieve_response_code( $response );
+		$log = Dintero_Logger::format_log('unknown', 'dintero.init_session', 'Create session', $payload, $response_json, $code);
+		Dintero_Logger::log($log);
+
+		return $response_json;
 	}
 }

--- a/includes/class-dintero-converter.php
+++ b/includes/class-dintero-converter.php
@@ -34,6 +34,6 @@ class Dintero_Converter {
 
 	public function get_order_tax_amount($order)
 	{
-		return absint( strval( floatval( $order->get_total_tax() ) * 100 ) )
+		return absint( strval( floatval( $order->get_total_tax() ) * 100 ) );
 	}
 }

--- a/includes/class-dintero-logger.php
+++ b/includes/class-dintero-logger.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * For debug logging
+ *
+ * @package    dintero-checkout-v2
+ * @subpackage dintero-checkout-v2/includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Dintero_Logger {
+	/**
+	 * Log message string
+	 *
+	 * @var $log
+	 */
+	private static $log;
+
+	/**
+	 * Logs an event.
+	 *
+	 * @param string $data The data string.
+	 */
+	public static function log( $data ) {
+
+		if ( DINTERO_WC()->config()->is( 'debug_logging' ) ) {
+			$message = self::format_data( $data );
+			if ( empty( self::$log ) ) {
+				self::$log = new WC_Logger();
+			}
+			self::$log->add( 'dintero-checkout-v2', wp_json_encode( $message ) );
+		}
+
+        // TODO: Enable logging failed calls to db
+		// if ( isset( $data['response']['code'] ) && ( $data['response']['code'] < 200 || $data['response']['code'] > 299 ) ) {
+		// 	self::log_to_db( $data );
+		// }
+	}
+
+	/**
+	 * Formats the log data to prevent json error.
+	 *
+	 * @param string $data Json string of data.
+	 * @return array
+	 */
+	public static function format_data( $data ) {
+		if ( isset( $data['request']['body'] ) ) {
+			$data['request']['body'] = json_decode( $data['request']['body'], true );
+		}
+		return $data;
+	}
+
+	/**
+	 * Formats the log data to be logged.
+	 *
+	 * @param string $dintero_session The dintero session id.
+	 * @param string $method The method.
+	 * @param string $title The title for the log.
+	 * @param array  $request_args The request args.
+	 * @param array  $response The response.
+	 * @param string $code The status code.
+	 * @return array
+	 */
+	public static function format_log( $dintero_session_id, $method, $title, $request_args, $response, $code ) {
+		// Unset the snippet to prevent issues in the response.
+		if ( isset( $response['html_snippet'] ) ) {
+			unset( $response['html_snippet'] );
+		}
+		// Unset the snippet to prevent issues in the request body.
+		if ( isset( $request_args['body'] ) ) {
+			$request_body = json_decode( $request_args['body'], true );
+			if ( isset( $request_body['html_snippet'] ) && $request_body['snippet'] ) {
+				unset( $request_body['html_snippet'] );
+				$request_args['body'] = wp_json_encode( $request_body );
+			}
+		}
+		return array(
+			'id'             => $dintero_session_id,
+			'type'           => $method,
+			'title'          => $title,
+			'request'        => $request_args,
+			'response'       => array(
+				'body' => $response,
+				'code' => $code,
+			),
+			'timestamp'      => date( 'Y-m-d H:i:s' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions -- Date is not used for display.
+			'stack'          => self::get_stack(),
+			'plugin_version' => DINTERO_CHECKOUT_VERSION,
+		);
+	}
+
+	/**
+	 * Gets the stack for the request.
+	 *
+	 * @return array
+	 */
+	public static function get_stack() {
+		$debug_data = debug_backtrace(); // phpcs:ignore WordPress.PHP.DevelopmentFunctions -- Data is not used for display.
+		$stack      = array();
+		foreach ( $debug_data as $data ) {
+			$extra_data = '';
+			if ( ! in_array( $data['function'], array( 'get_stack', 'format_log' ), true ) ) {
+				if ( in_array( $data['function'], array( 'do_action', 'apply_filters' ), true ) ) {
+					if ( isset( $data['object'] ) ) {
+						$priority   = $data['object']->current_priority();
+						$name       = key( $data['object']->current() );
+						$extra_data = $name . ' : ' . $priority;
+					}
+				}
+			}
+			$stack[] = $data['function'] . $extra_data;
+		}
+		return $stack;
+	}
+
+	/**
+	 * Logs an event in the WP DB.
+	 *
+	 * @param array $data The data to be logged.
+	 */
+	public static function log_to_db( $data ) {
+		$logs = get_option( 'dintero_debuglog_checkout', array() );
+
+		if ( ! empty( $logs ) ) {
+			$logs = json_decode( $logs );
+		}
+
+		$logs   = array_slice( $logs, -14 );
+		$logs[] = $data;
+		$logs   = wp_json_encode( $logs );
+		update_option( 'dintero_debuglog_checkout', $logs );
+	}
+
+}

--- a/includes/class-dintero-payment-gateway.php
+++ b/includes/class-dintero-payment-gateway.php
@@ -89,6 +89,14 @@ class Dintero_Payment_Gateway extends WC_Payment_Gateway {
 				'default'     => 'yes',
 				'desc_tip'    => true,
 			),
+			'debug_logging'               => array(
+				'title'       => __( 'Debug logging' ),
+				'label'       => __( 'Enable debug logging' ),
+				'type'        => 'checkbox',
+				'description' => __( 'Will log errors.' ),
+				'default'     => 'yes',
+				'desc_tip'    => true,
+			),
 			'client' 		  		  => array(
 				'title' => 'API Keys',
 				'type'  => 'Title'


### PR DESCRIPTION
Enable debug logging for dintero requests. Logs can be accessed at WooCommerce -> Status -> Logs.

![image](https://user-images.githubusercontent.com/509817/144621507-efa599d9-64a7-41e8-a117-12c961212f19.png)
