### PR TITLE
Develop redirect

### DIFF
--- a/classes/class-dintero-checkout-settings-fields.php
+++ b/classes/class-dintero-checkout-settings-fields.php
@@ -50,11 +50,14 @@ class Dintero_Settings_Fields {
 				'type'  => 'title',
 			),
 			'account_id'                 => array(
-				'title'       => __( 'Account ID', 'dintero-checkout-for-woocommerce' ),
-				'type'        => 'text',
-				'default'     => '',
-				'desc_tip'    => true,
-				'description' => __( 'Found under (SETTINGS → Account) in Dintero Backoffice.', 'dintero-checkout-for-woocommerce' ),
+				'title'             => __( 'Account ID', 'dintero-checkout-for-woocommerce' ),
+				'type'              => 'text',
+				'default'           => '',
+				'desc_tip'          => true,
+				'description'       => __( 'Found under (SETTINGS → Account) in Dintero Backoffice.', 'dintero-checkout-for-woocommerce' ),
+				'custom_attributes' => array(
+					'autocomplete' => 'off',
+				),
 			),
 			'client_id'                  => array(
 				'title'       => __( 'Client ID', 'dintero-checkout-for-woocommerce' ),
@@ -64,11 +67,14 @@ class Dintero_Settings_Fields {
 				'description' => __( 'Generated under (SETTINGS → API clients) in Dintero Backoffice.', 'dintero-checkout-for-woocommerce' ),
 			),
 			'client_secret'              => array(
-				'title'       => __( 'Client secret', 'dintero-checkout-for-woocommerce' ),
-				'type'        => 'password',
-				'default'     => '',
-				'desc_tip'    => true,
-				'description' => __( 'Generated under (SETTINGS → API clients) in Dintero Backoffice.', 'dintero-checkout-for-woocommerce' ),
+				'title'             => __( 'Client secret', 'dintero-checkout-for-woocommerce' ),
+				'type'              => 'password',
+				'default'           => '',
+				'desc_tip'          => true,
+				'description'       => __( 'Generated under (SETTINGS → API clients) in Dintero Backoffice.', 'dintero-checkout-for-woocommerce' ),
+				'custom_attributes' => array(
+					'autocomplete' => 'off',
+				),
 			),
 			'profile_id'                 => array(
 				'title'       => __( 'Profile ID', 'dintero-checkout-for-woocommerce' ),

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -112,6 +112,11 @@ class Dintero_Checkout_Cart {
 			$id      = ( empty( $item['variation_id'] ) ) ? $item['product_id'] : $item['variation_id'];
 			$product = wc_get_product( $id );
 
+			/* A misconfigured variation product will not have a unique variation id, but it will still have a unique variant. */
+			if ( ! empty( $item['variation'] ) ) {
+				$id .= ':' . reset( $item['variation'] );
+			}
+
 			$order_item = array(
 				/* NOTE: The id and line_id must match the same id and line_id on capture and refund. */
 				'id'          => strval( $id ),

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -85,6 +85,11 @@ class Dintero_Checkout_Order {
 			$id      = ( empty( $item['variation_id'] ) ) ? $item['product_id'] : $item['variation_id'];
 			$product = wc_get_product( $id );
 
+			/* A misconfigured variation product will not have a unique variation id, but it will still have a unique variant. */
+			if ( ! empty( $item['variation'] ) ) {
+				$id .= ':' . reset( $item['variation'] );
+			}
+
 			$order_item = array(
 				/* NOTE: The id and line_id must match the same id and line_id in session creation. */
 				'id'          => strval( $id ),


### PR DESCRIPTION
Changes:

- Add a workaround for misconfigured variant products. This should fix the issue with the line_id not being unique.
- Disable autocomplete for certain setting fields.

This was tested with correctly configured, and misconfigured variant products. Including placing and refunding order (partial and complete).