### PR TITLE
Develop redirect

### DIFF
--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -222,8 +222,7 @@ class Dintero_Checkout_Cart {
 
 			// Dintero needs to know this is an order with multiple shipping options by setting the 'type'.
 			if ( $is_multiple_shipping ) {
-				// FIXME: This ENUM has not yet been added in production by Dintero. We'll omit it for now per agreement.
-				// $shipping_option['type'] = 'shipping';
+				$shipping_option['type'] = 'shipping';
 
 				/* Since the shipping will be added to the list of products, it needs a quantity. */
 				$shipping_option['quantity'] = 1;

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -251,9 +251,7 @@ class Dintero_Checkout_Cart {
 			'postal_code'    => $order->get_billing_postcode(),
 			'postal_place'   => $order->get_billing_city(),
 			'country'        => $order->get_billing_country(),
-
-			/* Keep the '+' at the start (if available), remove every subsequent non-digit character. */
-			'phone_number'   => preg_replace( '/(?!^)[+]?[^\d]/', '', $order->get_billing_phone() ),
+			'phone_number'   => dintero_sanitize_phone_number( $order->get_billing_phone() ),
 			'email'          => $order->get_billing_email(),
 		);
 
@@ -286,9 +284,8 @@ class Dintero_Checkout_Cart {
 		);
 
 		// Check if a shipping phone number exist. Default to billing phone.
-		$phone = $order->get_shipping_phone();
-		/* Keep the '+' at the start (if available), remove every subsequent non-digit character. */
-		$shipping_address['phone_number'] = preg_replace( '/(?!^)[+]?[^\d]/', '', ( ! empty( $phone ) ) ? $phone : $order->get_billing_phone() );
+		$phone                            = $order->get_shipping_phone();
+		$shipping_address['phone_number'] = dintero_sanitize_phone_number( ! empty( $phone ) ? $phone : $order->get_billing_phone() );
 
 		/* Sanitize all values. Remove all empty elements (required by Dintero). */
 		return array_filter(

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -216,8 +216,8 @@ class Dintero_Checkout_Cart {
 				'operator'    => '',
 				'description' => '',
 				'title'       => $shipping_method->get_label(),
-				'vat_amount'  => ( empty( $shipping_method->get_shipping_tax() ) ) ? 0 : intval( number_format( $shipping_method->get_shipping_tax() * 100, 0, '', '' ) ),
-				'vat'         => ( empty( $shipping_method->get_cost() ) ) ? 0 : intval( number_format( ( $shipping_method->get_shipping_tax() / $shipping_method->get_cost() ) * 100, 0, '', '' ) ),
+				'vat_amount'  => ( empty( floatval( $shipping_method->get_shipping_tax() ) ) ) ? 0 : intval( number_format( $shipping_method->get_shipping_tax() * 100, 0, '', '' ) ),
+				'vat'         => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : intval( number_format( ( $shipping_method->get_shipping_tax() / $shipping_method->get_cost() ) * 100, 0, '', '' ) ),
 			);
 
 			// Dintero needs to know this is an order with multiple shipping options by setting the 'type'.

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -161,8 +161,7 @@ class Dintero_Checkout_Order {
 			);
 
 			// Dintero needs to know this is an order with multiple shipping options by setting the 'type'. */
-			// FIXME: This ENUM has not yet been added in production by Dintero. We'll omit it for now per agreement
-			// $shipping_option['type'] = 'shipping';
+			$shipping_option['type'] = 'shipping';
 
 			$shipping_option['amount'] += $shipping_option['vat_amount'];
 			$this->total_amount        += $shipping_option['amount'];

--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -125,6 +125,7 @@ if ( ! class_exists( 'Dintero' ) ) {
 			include_once DINTERO_CHECKOUT_PATH . '/classes/requests/post/class-dintero-checkout-refund-order.php';
 			include_once DINTERO_CHECKOUT_PATH . '/classes/requests/helpers/class-dintero-checkout-cart.php';
 			include_once DINTERO_CHECKOUT_PATH . '/classes/requests/helpers/class-dintero-checkout-order.php';
+			include_once DINTERO_CHECKOUT_PATH . '/includes/dintero-checkout-functions.php';
 
 			$this->api              = new Dintero_Checkout_API();
 			$this->order_management = Dintero_Checkout_Order_Management::get_instance();

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Utility functions.
+ *
+ * @package Dintero_Checkout/Includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sanitize phone number.
+ * Allow only '+' (if at the start), and numbers.
+ *
+ * @param string $phone Phone number.
+ * @return string
+ */
+function dintero_sanitize_phone_number( $phone ) {
+	return preg_replace( '/(?!^)[+]?[^\d]/', '', $phone );
+}


### PR DESCRIPTION
Changes:
- Add file for utility functions.
- Move the phone sanitizing function to the utility file.
- Fix division by zero on shipping cost happening due to checking for zero incorrectly.
- Set the product type as "shipping" (was previously not available as en ENUM) when the order contains multiple shipping options.

The `number_format` was not added to the utility file, since this is added in a helper class in the
[develop-embedded-dintero-checkout-express](https://github.com/Dintero/Dintero.Checkout.WooCommerce.V2/blob/develop-embedded-dintero-checkout-express/classes/requests/helpers/class-dintero-checkout-helper-base.php#L22-L24) branch.