### PR TITLE
Change plugin display name for the plugin store

### DIFF
--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -1,6 +1,6 @@
 <?php //phpcs:ignore
 /**
- * Plugin Name: Dintero Checkout for WooCommerce
+ * Plugin Name: Dintero Checkout for WooCommerce Payment Methods
  * Plugin URI: https://krokedil.com/products/
  * Description: Dintero offers a complete payment solution. Simplifying the payment process for you and the customer.
  * Author: Dintero, Krokedil


### PR DESCRIPTION
For SEO purposes we try to change the display name to `Dintero Checkout for WooCommerce Payment Methods`.

It's been changed on wordpress.org, but it's not reflected in the plugin list in wordpress. I suspect it's because of the magic values in the main php-file.