### PR TITLE
Fix branding for usage with default profile

### DIFF
--- a/classes/class-dintero-checkout-widget.php
+++ b/classes/class-dintero-checkout-widget.php
@@ -67,7 +67,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 		</p>
 		<p>
 			<label for="<?php echo esc_attr( $icon_color ); ?>"><?php esc_html_e( 'Icon color:', 'dintero-checkout-for-woocommerce' ); ?>
-			<input type="color" class="widefat colorpick" value="#cecece" id="<?php echo esc_attr( $icon_color ); ?>" name="<?php echo esc_attr( $icon_color ); ?>"  /></label>	
+			<input type="color" class="widefat colorpick" value="#cecece" id="<?php echo esc_attr( $icon_color ); ?>" name="<?php echo esc_attr( $icon_color ); ?>"  /></label>
 		</p>
 		<p>
 			<label for="<?php echo esc_attr( $background_color ); ?>"><?php esc_html_e( 'Background color:', 'dintero-checkout-for-woocommerce' ); ?>
@@ -114,6 +114,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 		$color    = $icon_color;
 		$width    = 600;
 		$template = 'dintero_left_frame';
+		$account_id  = $settings['account_id'];
 		$profile  = $settings['profile_id'];
 
 		if ( 'yes' !== $settings['branding_logo_color'] ) {
@@ -121,7 +122,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 			$color   = str_replace( '#', '', $settings['branding_logo_color_custom'] );
 		}
 
-		$icon_url = "https://checkout.dintero.com/v1/branding/profiles/$profile/variant/$variant/color/$color/width/$width/$template.svg";
+		$icon_url = "https://checkout.dintero.com/v1/branding/accounts/$account_id/profiles/$profile/variant/$variant/color/$color/width/$width/$template.svg";
 		?>
 			<div style="padding: 20px 0; <?php echo ( ! empty( $background_color ) ) ? esc_attr( "background-color: $background_color" ) : ''; ?> ">
 				<img style="margin: 0 auto;" src="<?php echo esc_attr( $icon_url ); ?>" style="max-width: 90%" alt="Dintero Logo" />


### PR DESCRIPTION
I thought this was already adressed, but seems not. When using a payment profile like `default` which doesn't contain an account_id, the branding API fails.

Therefore, we've added a new element to the path to specify which account_id we're on.
