### PR TITLE
Fix branding for usage with default profile

### DIFF
--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -63,23 +63,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 * @return string
 		 */
 		public function get_icon() {
-			$settings = get_option( 'woocommerce_dintero_checkout_settings' );
-
-			$variant  = 'colors';
-			$color    = 'cecece';
-			$width    = 600;
-			$template = 'dintero_left_frame';
-			$profile  = $settings['profile_id'];
-
-			if ( 'yes' !== $settings['branding_logo_color'] ) {
-				$variant = 'mono';
-				$color   = str_replace( '#', '', $settings['branding_logo_color_custom'] );
-			}
-
-			$icon_url = "https://checkout.dintero.com/v1/branding/profiles/$profile/variant/$variant/color/$color/width/$width/$template.svg";
-
-			return '<img src="' . esc_attr( $icon_url ) . '" style="max-width: 90%" alt="Dintero Logo" />';
-
+			return '<img src="' . esc_attr( dintero_get_brand_image_url() ) . '" style="max-width: 90%" alt="Dintero Logo" />';
 		}
 
 		/**

--- a/classes/class-dintero-checkout-widget.php
+++ b/classes/class-dintero-checkout-widget.php
@@ -99,6 +99,10 @@ class Dintero_Checkout_Widget extends WP_Widget {
 		return $instance;
 	}
 
+    private function environment($settings) {
+        return ( 'yes' === $settings['test_mode'] ) ? 'T' : 'P';
+    }
+
 	/**
 	 * Outputs the HTML content for showing the icons.
 	 *
@@ -114,7 +118,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 		$color    = $icon_color;
 		$width    = 600;
 		$template = 'dintero_left_frame';
-		$account_id  = $settings['account_id'];
+		$account_id  = $this->environment($settings) . $settings['account_id'];
 		$profile  = $settings['profile_id'];
 
 		if ( 'yes' !== $settings['branding_logo_color'] ) {

--- a/classes/class-dintero-checkout-widget.php
+++ b/classes/class-dintero-checkout-widget.php
@@ -112,21 +112,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 	 * @return void
 	 */
 	private function print_icon( $icon_color = 'cecece', $background_color = false ) {
-		$settings = get_option( 'woocommerce_dintero_checkout_settings' );
-
-		$variant    = 'colors';
-		$color      = $icon_color;
-		$width      = 600;
-		$template   = 'dintero_left_frame';
-		$account_id = $this->environment( $settings ) . $settings['account_id'];
-		$profile    = $settings['profile_id'];
-
-		if ( 'yes' !== $settings['branding_logo_color'] ) {
-			$variant = 'mono';
-			$color   = str_replace( '#', '', $settings['branding_logo_color_custom'] );
-		}
-
-		$icon_url = "https://checkout.dintero.com/v1/branding/accounts/$account_id/profiles/$profile/variant/$variant/color/$color/width/$width/$template.svg";
+		$icon_url = dintero_get_brand_image_url( $icon_color );
 		?>
 			<div style="padding: 20px 0; <?php echo ( ! empty( $background_color ) ) ? esc_attr( "background-color: $background_color" ) : ''; ?> ">
 				<img style="margin: 0 auto;" src="<?php echo esc_attr( $icon_url ); ?>" style="max-width: 90%" alt="Dintero Logo" />

--- a/classes/class-dintero-checkout-widget.php
+++ b/classes/class-dintero-checkout-widget.php
@@ -67,7 +67,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 		</p>
 		<p>
 			<label for="<?php echo esc_attr( $icon_color ); ?>"><?php esc_html_e( 'Icon color:', 'dintero-checkout-for-woocommerce' ); ?>
-			<input type="color" class="widefat colorpick" value="#cecece" id="<?php echo esc_attr( $icon_color ); ?>" name="<?php echo esc_attr( $icon_color ); ?>"  /></label>	
+			<input type="color" class="widefat colorpick" value="#cecece" id="<?php echo esc_attr( $icon_color ); ?>" name="<?php echo esc_attr( $icon_color ); ?>"  /></label>
 		</p>
 		<p>
 			<label for="<?php echo esc_attr( $background_color ); ?>"><?php esc_html_e( 'Background color:', 'dintero-checkout-for-woocommerce' ); ?>
@@ -114,6 +114,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 		$color    = $icon_color;
 		$width    = 600;
 		$template = 'dintero_left_frame';
+		$account_id  = $settings['account_id'];
 		$profile  = $settings['profile_id'];
 
 		if ( 'yes' !== $settings['branding_logo_color'] ) {
@@ -121,7 +122,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 			$color   = str_replace( '#', '', $settings['branding_logo_color_custom'] );
 		}
 
-		$icon_url = "https://checkout.dintero.com/v1/branding/profiles/$profile/variant/$variant/color/$color/width/$width/$template.svg";
+		$icon_url = "https://checkout.dintero.com/v1/branding/accounts/$account_id/profiles/$profile/variant/$variant/color/$color/width/$width/$template.svg";
 		?>
 			<div style="padding: 20px 0; <?php echo ( ! empty( $background_color ) ) ? esc_attr( "background-color: $background_color" ) : ''; ?> ">
 				<img style="margin: 0 auto;" src="<?php echo esc_attr( $icon_url ); ?>" style="max-width: 90%" alt="Dintero Logo" />

--- a/classes/class-dintero-checkout-widget.php
+++ b/classes/class-dintero-checkout-widget.php
@@ -99,9 +99,9 @@ class Dintero_Checkout_Widget extends WP_Widget {
 		return $instance;
 	}
 
-    private function environment($settings) {
-        return ( 'yes' === $settings['test_mode'] ) ? 'T' : 'P';
-    }
+	private function environment( $settings ) {
+		return ( 'yes' === $settings['test_mode'] ) ? 'T' : 'P';
+	}
 
 	/**
 	 * Outputs the HTML content for showing the icons.
@@ -114,12 +114,12 @@ class Dintero_Checkout_Widget extends WP_Widget {
 	private function print_icon( $icon_color = 'cecece', $background_color = false ) {
 		$settings = get_option( 'woocommerce_dintero_checkout_settings' );
 
-		$variant  = 'colors';
-		$color    = $icon_color;
-		$width    = 600;
-		$template = 'dintero_left_frame';
-		$account_id  = $this->environment($settings) . $settings['account_id'];
-		$profile  = $settings['profile_id'];
+		$variant    = 'colors';
+		$color      = $icon_color;
+		$width      = 600;
+		$template   = 'dintero_left_frame';
+		$account_id = $this->environment( $settings ) . $settings['account_id'];
+		$profile    = $settings['profile_id'];
 
 		if ( 'yes' !== $settings['branding_logo_color'] ) {
 			$variant = 'mono';

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -150,3 +150,27 @@ function dintero_confirm_order( $order, $transaction_id ) {
 		update_post_meta( $order->get_id(), '_wc_dintero_shipping_id', $shipping_option_id );
 	}
 }
+
+/**
+ * The URL to the branding image.
+ *
+ * @param  string $icon_color A hexadecimal RGB value for the foreground color. Default is #cecece.
+ * @return string URL
+ */
+function dintero_get_brand_image_url( $icon_color = 'cecece' ) {
+	$settings = get_option( 'woocommerce_dintero_checkout_settings' );
+
+	$variant  = 'colors';
+	$color    = $icon_color;
+	$width    = 600;
+	$template = 'dintero_left_frame';
+	$account  = ( ( 'yes' === $settings['test_mode'] ) ? 'T' : 'P' ) . $settings['account_id'];
+	$profile  = $settings['profile_id'];
+
+	if ( 'yes' !== $settings['branding_logo_color'] ) {
+		$variant = 'mono';
+		$color   = str_replace( '#', '', $settings['branding_logo_color_custom'] );
+	}
+
+	return "https://checkout.dintero.com/v1/branding/accounts/$account/profiles/$profile/variant/$variant/color/$color/width/$width/$template.svg";
+}


### PR DESCRIPTION
I thought this was already adressed, but seems not. When using a payment profile like `default` which doesn't contain an account_id, the branding API fails.

Therefore, we've added a new element to the path to specify which account_id we're on.
