### PR TITLE
Hide the line id item meta data

### DIFF
--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -53,20 +53,20 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			add_action(
 				'woocommerce_add_order_item_meta',
 				function( $item_id, $values, $key ) {
-					wc_add_order_item_meta( $item_id, 'dintero_checkout_line_id', $key, true );
+					wc_add_order_item_meta( $item_id, '_dintero_checkout_line_id', $key, true );
 				},
 				10,
 				3
 			);
 
 			/**
-			 * By default, a custom meta data will be displayed on the order page. Since the meta data dintero_checkout_line_id is an implementation detail,
+			 * By default, a custom meta data will be displayed on the order page. Since the meta data _dintero_checkout_line_id is an implementation detail,
 			 * we should hide it on the order page.
 			 */
 			add_filter(
 				'woocommerce_hidden_order_itemmeta',
 				function( $hidden_meta ) {
-					$hidden_meta[] = 'dintero_checkout_line_id';
+					$hidden_meta[] = '_dintero_checkout_line_id';
 					return $hidden_meta;
 				}
 			);

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -146,12 +146,12 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 
 		if ( is_a( $this->order, 'WC_Order_Refund' ) ) {
 			// Retrieve the same get_id that was set in the checkout.
-			$line_id = wc_get_order_item_meta( $order_item->get_meta( '_refunded_item_id' ), 'dintero_checkout_line_id', true );
+			$line_id = wc_get_order_item_meta( $order_item->get_meta( '_refunded_item_id' ), '_dintero_checkout_line_id', true );
 			if ( empty( $line_id ) ) {
 				$line_id = $order_item->get_meta( '_refunded_item_id' );
 			}
 		} else {
-			$line_id = $order_item->get_meta( 'dintero_checkout_line_id' );
+			$line_id = $order_item->get_meta( '_dintero_checkout_line_id' );
 		}
 
 		return array(


### PR DESCRIPTION
The filter woocommerce_hidden_order_itemmeta only hides the meta data on the order page. We need to prefix the field key by underscore to hide it everywhere else (e.g., in email and PDF documents)