### PR TITLE
Add cart item key to order meta

### DIFF
--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -53,20 +53,20 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			add_action(
 				'woocommerce_checkout_create_order_line_item',
 				function( $item, $cart_item_key ) {
-					$item->update_meta_data( '_cart_item_key', $cart_item_key );
+					$item->update_meta_data( '_dintero_checkout_line_id', $cart_item_key );
 				},
 				10,
 				2
 			);
 
 			/**
-			 * By default, a custom meta data will be displayed on the order page. Since the meta data _cart_item_key is an implementation detail,
+			 * By default, a custom meta data will be displayed on the order page. Since the meta data _dintero_checkout_line_id is an implementation detail,
 			 * we should hide it on the order page. The meta key has to be prefixed with an underscore (_) to also hide the meta data beyond the order page (e.g., in emails, PDF documents).
 			 */
 			add_filter(
 				'woocommerce_hidden_order_itemmeta',
 				function( $hidden_meta ) {
-					$hidden_meta[] = '_cart_item_key';
+					$hidden_meta[] = '_dintero_checkout_line_id';
 					return $hidden_meta;
 				}
 			);

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -145,9 +145,9 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 		$product = wc_get_product( $id );
 
 		if ( is_a( $this->order, 'WC_Order_Refund' ) ) {
-			$line_id = wc_get_order_item_meta( $order_item->get_meta( '_refunded_item_id' ), '_cart_item_key', true );
+			$line_id = wc_get_order_item_meta( $order_item->get_meta( '_refunded_item_id' ), '_dintero_checkout_line_id', true );
 		} else {
-			$line_id = $order_item->get_meta( '_cart_item_key' );
+			$line_id = $order_item->get_meta( '_dintero_checkout_line_id' );
 		}
 
 		$vat_rate = WC_Tax::get_base_tax_rates( $product->get_tax_class() );


### PR DESCRIPTION
The 'woocommerce_new_order_item' does not provide the cart_item_key which is required for handling the order after it has been placed.