### PR TITLE
Fix cannot change to a different payment method

### DIFF
--- a/classes/class-dintero-checkout-templates.php
+++ b/classes/class-dintero-checkout-templates.php
@@ -129,7 +129,7 @@ class Dintero_Checkout_Templates {
 			}
 
 			// If another gateway was, but is made unavailable during checkout, and Dintero Checkout is available, and is the first gateway...
-			if ( ! in_array( $chosen_payment_method, $available_gateways, true ) && 'dintero_checkout' === array_key_first( $available_gateways ) ) {
+			if ( ! isset( $available_gateways[ $chosen_payment_method ] ) && 'dintero_checkout' === array_key_first( $available_gateways ) ) {
 				return $checkout_express_template;
 			}
 		}


### PR DESCRIPTION
This fixes the issue with not being able to change payment method if Dintero Checkout is selected in the checkout page, AND is the first payment gateway in the WC settings.

This would also cause the layout to shift from two-column to single-column. This should now also be resolved.