### PR TITLE
Develop refund status

### DIFF
--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -248,6 +248,14 @@ class Dintero_Checkout_Order_Management {
 			return;
 		}
 
+		if ( did_action( 'woocommerce_order_status_refunded' ) ) {
+			$settings      = get_option( 'woocommerce_dintero_checkout_settings' );
+			$manual_refund = $settings['order_management_manual_refund'] ?? 'no';
+			if ( 'no' === $manual_refund || get_post_meta( $order_id, $this->status['refunded'], true ) ) {
+				return;
+			}
+		}
+
 		// Check if the order has at least been processed. This also covers for checking if the order requires further authorization.
 		if ( empty( $order->get_date_paid() ) ) {
 			return;

--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -55,6 +55,7 @@ class Dintero_Checkout_Order_Management {
 	public function __construct() {
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_order' ) );
 		add_action( 'woocommerce_order_status_cancelled', array( $this, 'cancel_order' ) );
+		add_action( 'woocommerce_order_status_refunded', array( $this, 'refund_order' ) );
 	}
 
 	/**
@@ -240,7 +241,7 @@ class Dintero_Checkout_Order_Management {
 	 * @param string $reason The reason for the refund.
 	 * @return boolean|null TRUE on success, FALSE on unrecoverable failure, and null if not relevant or valid.
 	 */
-	public function refund_order( $order_id, $reason ) {
+	public function refund_order( $order_id, $reason = '' ) {
 		$order = wc_get_order( $order_id );
 
 		if ( 'dintero_checkout' !== $order->get_payment_method() ) {

--- a/classes/class-dintero-checkout-settings-fields.php
+++ b/classes/class-dintero-checkout-settings-fields.php
@@ -170,6 +170,17 @@ class Dintero_Settings_Fields {
 					'on-hold'    => __( 'On-hold', 'dintero-checkout-for-woocommerce' ),
 				),
 			),
+			/* Order Management */
+			'order_management_title'                  => array(
+				'title' => __( 'Order Management', 'dintero-checkout-for-woocommerce' ),
+				'type'  => 'title',
+			),
+			'order_management_manual_refund'          => array(
+				'title'   => __( 'Refund by changing order status', 'dintero-checkout-for-woocommerce' ),
+				'label'   => __( 'Trigger refund in Dintero when WooCommerce order status is manually changed to <u>Refunded</u>.', 'dintero-checkout-for-woocommerce' ),
+				'type'    => 'checkbox',
+				'default' => 'no',
+			),
 			/* The Dintero Checkout Express Settings */
 			'dintero_checkout_express_settings_title' => array(
 				'title' => __( 'Dintero Checkout Express Settings', 'dintero-checkout-for-woocommerce' ),


### PR DESCRIPTION
Setting the order status to "Refunded" will now automatically trigger a refund in Dintero. Previously, this would require the merchant to manually refund the order through the backoffice as well as this is considered a ["manual refund"](https://woocommerce.com/document/woocommerce-refunds/#manual-refunds).

As this is not the default WooCommerce behavior, this change has to be enabled through the plugin's settings.