### PR TITLE
136 renew access token on account id change

### DIFF
--- a/classes/class-dintero-checkout-settings-fields.php
+++ b/classes/class-dintero-checkout-settings-fields.php
@@ -286,11 +286,10 @@ class Dintero_Settings_Fields {
 	 *
 	 * @param  array $new_settings The Dintero WooCommerce settings that were changed.
 	 * @param  array $old_settings The Dintero WooCommerce settings before the change.
-	 * @return void Maybe delete the dintero_checkout_access_token transient.
+	 * @return void Delete the dintero_checkout_access_token transient.
 	 */
 	public static function maybe_update_access_token( $new_settings, $old_settings ) {
-		if ( $new_settings['test_mode'] !== $old_settings['test_mode'] ) {
-			delete_transient( 'dintero_checkout_access_token' );
-		}
+		// Always renew the access token when the settings is updated.
+		delete_transient( 'dintero_checkout_access_token' );
 	}
 }

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -64,7 +64,17 @@ function dintero_print_error_message( $wp_error ) {
 	}
 
 	foreach ( $wp_error->get_error_messages() as $error ) {
-		$message = is_array( $error ) ? implode( ' ', $error ) : $error;
+		$message = $error;
+		if ( is_array( $error ) ) {
+			$error   = array_filter(
+				$error,
+				function( $e ) {
+					return ! empty( $e );
+				}
+			);
+			$message = implode( ' ', $error );
+		}
+
 		$print( $message, 'error' );
 	}
 }


### PR DESCRIPTION
- Remove the access token whenever the settings are modified.
- Fixed the error message writing "Array" when there is a nested, empty array in the error messages object.