### PR TITLE
Add session ID when logging frontend error

### DIFF
--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -500,10 +500,10 @@ jQuery( function( $ ) {
 							// Strip HTML code from messages.
 							const messages = data.messages.replace( /<\/?[^>]+(>|$)\s+/g, '' );
 							dinteroCheckoutForWooCommerce.printNotice( messages );
-							dinteroCheckoutForWooCommerce.logToFile( 'Checkout error | ' + messages );
+							dinteroCheckoutForWooCommerce.logToFile(dinteroCheckoutParams.SID + ' | Checkout error | ' + messages );
 							dinteroCheckoutForWooCommerce.failOrder( 'submission', messages, callback );
 						} else {
-							dinteroCheckoutForWooCommerce.logToFile( 'Checkout error | No message' );
+							dinteroCheckoutForWooCommerce.logToFile(dinteroCheckoutParams.SID + ' | Checkout error | No message' );
 							dinteroCheckoutForWooCommerce.failOrder( 'submission', 'Checkout error', callback );
 						}
 
@@ -520,9 +520,9 @@ jQuery( function( $ ) {
 					console.log( 'error data', data );
 					console.log( 'error data response text', data.responseText );
 					try {
-						dinteroCheckoutForWooCommerce.logToFile( 'AJAX error | ' + JSON.stringify( data ) );
+						dinteroCheckoutForWooCommerce.logToFile( dinteroCheckoutParams.SID + ' | AJAX error | ' + JSON.stringify( data ) );
 					} catch ( e ) {
-						dinteroCheckoutForWooCommerce.logToFile( 'AJAX error | Failed to parse error message.' );
+						dinteroCheckoutForWooCommerce.logToFile( dinteroCheckoutParams.SID +' | AJAX error | Failed to parse error message.' );
 					}
 					dinteroCheckoutForWooCommerce.failOrder( 'ajax-error', 'Internal Server Error', callback );
 				},


### PR DESCRIPTION
Currently, we retrieve the session ID directly from WC session object, but that sometimes fails whereas the SID is always available whenever the express checkout is initialized.