### PR TITLE
Check if order is authorized via API

### DIFF
--- a/classes/class-dintero-checkout-callback.php
+++ b/classes/class-dintero-checkout-callback.php
@@ -179,7 +179,7 @@ class Dintero_Checkout_Callback {
 				$order->save();
 				break;
 			default:
-				Dintero_Checkout_Logger::log( sprintf( "CALLBACK: Unknown order status on callback. {$dintero_order['status']}. WC order id: %s (transaction ID: %s)", $order->get_id(), $transaction_id ) );
+				Dintero_Checkout_Logger::log( sprintf( "CALLBACK: Unknown order status on callback: {$dintero_order['status']}. WC order id: %s (transaction ID: %s)", $order->get_id(), $transaction_id ) );
 				break;
 		}
 	}

--- a/classes/class-dintero-checkout-meta-box.php
+++ b/classes/class-dintero-checkout-meta-box.php
@@ -47,12 +47,6 @@ class Dintero_Checkout_Meta_Box {
 		$order_id = get_the_ID();
 		$order    = wc_get_order( $order_id );
 
-		// Check if the order has been paid.
-		if ( empty( $order->get_date_paid() ) && ! in_array( $order->get_status(), array( 'on-hold' ), true ) ) {
-			$this->print_error_content( __( 'The order has not been authorized by Dintero.', 'dintero-checkout-for-woocommerce' ) );
-			return;
-		}
-
 		if ( ! empty( get_post_meta( $order_id, '_transaction_id', true ) ) ) {
 
 			$dintero_order = Dintero()->api->get_order( $order->get_transaction_id() );
@@ -63,6 +57,10 @@ class Dintero_Checkout_Meta_Box {
 			}
 
 			$this->print_content( $dintero_order );
+
+			if ( empty( $order->get_date_paid() ) && ! in_array( $order->get_status(), array( 'on-hold' ), true ) ) {
+				$this->print_error_content( __( 'The order has not been authorized by Dintero.', 'dintero-checkout-for-woocommerce' ) );
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, we cache the order status if the order requires authorization. This acts as a lock to prevents the customer from activating the order in WC. This implementation assumes that at some point, when the order is authorized by Dintero, an authorization callback will be triggered, and we can unlock the order. However, for various reasons, this has not always been the case, and the order remain locked indefinitely.

- if the order is locked, check via API if the order has been authorized yet (thus bypassing the cache), and unlock accordingly when the merchant attempts to change the order status.
- display the default content of the meta box even if the order requires authorization. Currently, we only display a standard notice.

Related task: https://app.clickup.com/t/865c29qtc