### PR TITLE
Version 1.6.1

### DIFF
--- a/classes/class-dintero-checkout-callback.php
+++ b/classes/class-dintero-checkout-callback.php
@@ -179,7 +179,7 @@ class Dintero_Checkout_Callback {
 				$order->save();
 				break;
 			default:
-				Dintero_Checkout_Logger::log( sprintf( "CALLBACK: Unknown order status on callback. {$dintero_order['status']}. WC order id: %s (transaction ID: %s)", $order->get_id(), $transaction_id ) );
+				Dintero_Checkout_Logger::log( sprintf( "CALLBACK: Unknown order status on callback: {$dintero_order['status']}. WC order id: %s (transaction ID: %s)", $order->get_id(), $transaction_id ) );
 				break;
 		}
 	}

--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -131,7 +131,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			$order     = wc_get_order( $order_id );
 			$reference = WC()->session->get( 'dintero_merchant_reference' );
 			update_post_meta( $order_id, '_dintero_merchant_reference', $reference );
-			$order->add_order_note( __( 'Dintero Order created with reference ', 'dintero-checkout-for-woocommerce' ) . $reference );
+			$order->add_order_note( __( 'Dintero order created with reference ', 'dintero-checkout-for-woocommerce' ) . $reference );
 
 			return array(
 				'result' => 'success',

--- a/classes/class-dintero-checkout-meta-box.php
+++ b/classes/class-dintero-checkout-meta-box.php
@@ -47,12 +47,6 @@ class Dintero_Checkout_Meta_Box {
 		$order_id = get_the_ID();
 		$order    = wc_get_order( $order_id );
 
-		// Check if the order has been paid.
-		if ( empty( $order->get_date_paid() ) && ! in_array( $order->get_status(), array( 'on-hold' ), true ) ) {
-			$this->print_error_content( __( 'The order has not been authorized by Dintero.', 'dintero-checkout-for-woocommerce' ) );
-			return;
-		}
-
 		if ( ! empty( get_post_meta( $order_id, '_transaction_id', true ) ) ) {
 
 			$dintero_order = Dintero()->api->get_order( $order->get_transaction_id() );
@@ -63,6 +57,10 @@ class Dintero_Checkout_Meta_Box {
 			}
 
 			$this->print_content( $dintero_order );
+
+			if ( empty( $order->get_date_paid() ) && ! in_array( $order->get_status(), array( 'on-hold' ), true ) ) {
+				$this->print_error_content( __( 'The order has not been authorized by Dintero.', 'dintero-checkout-for-woocommerce' ) );
+			}
 		}
 	}
 

--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -399,11 +399,10 @@ class Dintero_Checkout_Order_Management {
 		}
 
 		if ( 'ON_HOLD' !== $dintero_order['status'] ) {
-			$order->delete_meta_data( $this->status( 'on_hold' ) );
-			$order->save();
+			dintero_confirm_order( $order, $order->get_transaction_id() );
 		}
 
-		return empty( $order->get_meta( $this->status( 'on_hold' ) ) );
+		return 'ON_HOLD' !== $dintero_order;
 	}
 
 	/**

--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -5,12 +5,12 @@
  * Description: Dintero offers a complete payment solution. Simplifying the payment process for you and the customer.
  * Author: Dintero, Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.6.0
+ * Version: 1.6.1
  * Text Domain: dintero-checkout-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 6.1.0
- * WC tested up to: 7.2.0
+ * WC tested up to: 7.9.0
  *
  * Copyright (c) 2023 Krokedil
  *
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'DINTERO_CHECKOUT_VERSION', '1.6.0' );
+define( 'DINTERO_CHECKOUT_VERSION', '1.6.1' );
 define( 'DINTERO_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_MAIN_FILE', __FILE__ );

--- a/languages/dintero-checkout-for-woocommerce.pot
+++ b/languages/dintero-checkout-for-woocommerce.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/Dintero.Checkout.WooCommerce.V2\n"
-"POT-Creation-Date: 2023-03-09 14:17:01+00:00\n"
+"POT-Creation-Date: 2023-08-28 08:45:19+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -58,30 +58,30 @@ msgid "Dintero Checkout"
 msgstr ""
 
 #: classes/class-dintero-checkout-gateway.php:134
-msgid "Dintero Order created with reference "
+msgid "Dintero order created with reference "
 msgstr ""
 
 #: classes/class-dintero-checkout-gateway.php:159
 msgid "Customer redirected to Dintero payment page."
 msgstr ""
 
-#: classes/class-dintero-checkout-meta-box.php:52
-msgid "The order has not been authorized by Dintero."
-msgstr ""
-
-#: classes/class-dintero-checkout-meta-box.php:61
+#: classes/class-dintero-checkout-meta-box.php:55
 msgid "Failed to retrieve the order from Dintero."
 msgstr ""
 
-#: classes/class-dintero-checkout-meta-box.php:88
+#: classes/class-dintero-checkout-meta-box.php:62
+msgid "The order has not been authorized by Dintero."
+msgstr ""
+
+#: classes/class-dintero-checkout-meta-box.php:86
 msgid "Dintero order status: "
 msgstr ""
 
-#: classes/class-dintero-checkout-meta-box.php:89
+#: classes/class-dintero-checkout-meta-box.php:87
 msgid "Payment method: "
 msgstr ""
 
-#: classes/class-dintero-checkout-meta-box.php:91
+#: classes/class-dintero-checkout-meta-box.php:89
 msgid "Environment: "
 msgstr ""
 
@@ -423,13 +423,13 @@ msgstr ""
 msgid "Background color:"
 msgstr ""
 
-#: classes/requests/helpers/class-dintero-checkout-cart.php:286
-#: classes/requests/helpers/class-dintero-checkout-cart.php:309
-#: classes/requests/helpers/class-dintero-checkout-order.php:240
+#: classes/requests/helpers/class-dintero-checkout-cart.php:293
+#: classes/requests/helpers/class-dintero-checkout-cart.php:316
+#: classes/requests/helpers/class-dintero-checkout-order.php:248
 msgid "Gift card"
 msgstr ""
 
-#: classes/requests/helpers/class-dintero-checkout-cart.php:330
+#: classes/requests/helpers/class-dintero-checkout-cart.php:337
 msgid "Gift card:"
 msgstr ""
 
@@ -451,20 +451,20 @@ msgstr ""
 msgid "Select another payment method"
 msgstr ""
 
-#: includes/dintero-checkout-functions.php:134
+#: includes/dintero-checkout-functions.php:141
 #. translators: %s the Dintero transaction ID.
 msgid ""
 "The order was placed successfully, but requires further authorization by "
 "Dintero. Transaction ID: %s"
 msgstr ""
 
-#: includes/dintero-checkout-functions.php:141
-#. translators: %s the Dintero transaction ID.
-msgid "Payment via Dintero Checkout. Transaction ID: %s"
+#: includes/dintero-checkout-functions.php:151
+msgid "The order has been authorized."
 msgstr ""
 
-#: includes/dintero-checkout-functions.php:146
-msgid "The order was placed successfully."
+#: includes/dintero-checkout-functions.php:154
+#. translators: %s the Dintero transaction ID.
+msgid "The order was placed successfully via Dintero Checkout. Transaction ID: %s"
 msgstr ""
 
 #: templates/dintero-checkout-express.php:10

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: dintero, krokedil, NiklasHogefjord
 Tags: woocommerce, dintero, ecommerce, e-commerce, checkout
 Requires at least: 5.8.3
-Tested up to: 6.1.1
+Tested up to: 6.3.0
 Requires PHP: 7.0
 WC requires at least: 6.1.0
-WC tested up to: 7.2.0
-Stable tag: 1.6.0
+WC tested up to: 7.9.0
+Stable tag: 1.6.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,11 @@ Go to [https://www.dintero.com/contact-us](https://www.dintero.com/contact-us) t
 1. The plugin settings screen where you set up the details to connect to Dintero.
 
 == Changelog ==
+= 2023.08.28    - version 1.6.1 =
+* Fix           - Fixed an issue where you could no longer cancel an on-hold orders if the default order status was set to on-hold for not yet authorized orders.
+* Fix           - Fixed an issue where orders pending authorization were locked even after being authorized.
+* Tweak         - The order information will now be displayed in the meta box even while pending authorization.
+
 = 2023.05.10    - version 1.6.0 =
 * Feature       - If the product image and/or thumbnail is available, their URL will be sent in the request.
 * Tweak         - The access token is now always renewed whenever the settings are updated.


### PR DESCRIPTION
* Fix           - Fixed an issue where you could no longer cancel an on-hold orders if the default order status was set to on-hold for not yet authorized orders.
* Fix           - Fixed an issue where orders pending authorization were locked even after being authorized.
* Tweak         - The order information will now be displayed in the meta box even while pending authorization.