### PR TITLE
Add setting for pending authorization

### DIFF
--- a/classes/class-dintero-checkout-settings-fields.php
+++ b/classes/class-dintero-checkout-settings-fields.php
@@ -161,13 +161,22 @@ class Dintero_Settings_Fields {
 				'title' => __( 'Order statuses', 'dintero-checkout-for-woocommerce' ),
 				'type'  => 'title',
 			),
-			'order_statuses'                          => array(
-				'title'   => 'Default order status when authorized',
+			'order_status_authorized'                 => array(
+				'title'   => 'Default order status when <u>authorized</u>',
 				'type'    => 'select',
 				'default' => 'processing',
 				'options' => array(
 					'processing' => __( 'Processing', 'dintero-checkout-for-woocommerce' ),
 					'on-hold'    => __( 'On-hold', 'dintero-checkout-for-woocommerce' ),
+				),
+			),
+			'order_status_pending_authorization'      => array(
+				'title'   => 'Default order status when <u>pending authorization</u>',
+				'type'    => 'select',
+				'default' => 'manual-review',
+				'options' => array(
+					'manual-review' => __( 'Manual review', 'dintero-checkout-for-woocommerce' ),
+					'on-hold'       => __( 'On-hold', 'dintero-checkout-for-woocommerce' ),
 				),
 			),
 			/* Order Management */

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -53,10 +53,8 @@ function dintero_print_error_message( $wp_error ) {
 		if ( function_exists( 'wc_add_notice' ) ) {
 			$print = 'wc_add_notice';
 		}
-	} else {
-		if ( function_exists( 'wc_print_notice' ) ) {
+	} elseif ( function_exists( 'wc_print_notice' ) ) {
 			$print = 'wc_print_notice';
-		}
 	}
 
 	if ( ! isset( $print ) ) {
@@ -68,7 +66,7 @@ function dintero_print_error_message( $wp_error ) {
 		if ( is_array( $error ) ) {
 			$error   = array_filter(
 				$error,
-				function( $e ) {
+				function ( $e ) {
 					return ! empty( $e );
 				}
 			);
@@ -127,9 +125,10 @@ function dintero_update_wc_shipping( $data ) {
  */
 function dintero_confirm_order( $order, $transaction_id ) {
 	$order_id = $order->get_id();
+	$settings = get_option( 'woocommerce_dintero_checkout_settings' );
 
 	// Save the environment mode for use in the meta box.
-	$order->update_meta_data( '_wc_dintero_checkout_environment', 'yes' === get_option( 'woocommerce_dintero_checkout_settings' )['test_mode'] ? 'Test' : 'Production' );
+	$order->update_meta_data( '_wc_dintero_checkout_environment', 'yes' === $settings['test_mode'] ? 'Test' : 'Production' );
 
 	$order->update_meta_data( '_dintero_transaction_id', $transaction_id );
 	$dintero_order         = Dintero()->api->get_order( $transaction_id );
@@ -137,8 +136,11 @@ function dintero_confirm_order( $order, $transaction_id ) {
 	if ( $require_authorization ) {
 		$order->set_transaction_id( $transaction_id );
 		$order->update_meta_data( Dintero()->order_management->status( 'on_hold' ), $transaction_id );
+
+		$default_pending_authorization = $settings['order_status_pending_authorization'] ?? 'manual-review';
+
 		// translators: %s the Dintero transaction ID.
-		$order->update_status( 'manual-review', sprintf( __( 'The order was placed successfully, but requires further authorization by Dintero. Transaction ID: %s', 'dintero-checkout-for-woocommerce' ), $transaction_id ) );
+		$order->update_status( $default_pending_authorization, sprintf( __( 'The order was placed successfully, but requires further authorization by Dintero. Transaction ID: %s', 'dintero-checkout-for-woocommerce' ), $transaction_id ) );
 		Dintero_Checkout_Logger::log( "REDIRECT: The WC order $order_id (transaction ID: $transaction_id) will require further authorization from Dintero." );
 	} else {
 		// Check if the order has already been processed.
@@ -154,10 +156,10 @@ function dintero_confirm_order( $order, $transaction_id ) {
 			$order->add_order_note( sprintf( __( 'The order was placed successfully via Dintero Checkout. Transaction ID: %s', 'dintero-checkout-for-woocommerce' ), $transaction_id ) );
 		}
 
-		$default_status = get_option( 'woocommerce_dintero_checkout_settings' )['order_statuses'];
-		if ( 'processing' !== $default_status ) {
+		$default_status_authorized = $settings['order_status_authorized'] ?? 'processing';
+		if ( 'processing' !== $default_status_authorized ) {
 			$order->set_transaction_id( $transaction_id );
-			$order->set_status( $default_status );
+			$order->set_status( $default_status_authorized );
 			if ( ! $order->get_date_paid( 'edit' ) ) {
 				$order->set_date_paid( time() );
 			}


### PR DESCRIPTION
Add setting to let the merchant change the default order status for transactions that has not yet been authorized (require manual review).

Related task: https://app.clickup.com/t/865d2ednd