### PR TITLE
Version 1.7.0

### DIFF
--- a/classes/class-dintero-checkout-settings-fields.php
+++ b/classes/class-dintero-checkout-settings-fields.php
@@ -161,13 +161,22 @@ class Dintero_Settings_Fields {
 				'title' => __( 'Order statuses', 'dintero-checkout-for-woocommerce' ),
 				'type'  => 'title',
 			),
-			'order_statuses'                          => array(
-				'title'   => 'Default order status when authorized',
+			'order_status_authorized'                 => array(
+				'title'   => 'Default order status when <u>authorized</u>',
 				'type'    => 'select',
 				'default' => 'processing',
 				'options' => array(
 					'processing' => __( 'Processing', 'dintero-checkout-for-woocommerce' ),
 					'on-hold'    => __( 'On-hold', 'dintero-checkout-for-woocommerce' ),
+				),
+			),
+			'order_status_pending_authorization'      => array(
+				'title'   => 'Default order status when <u>pending authorization</u>',
+				'type'    => 'select',
+				'default' => 'manual-review',
+				'options' => array(
+					'manual-review' => __( 'Manual review', 'dintero-checkout-for-woocommerce' ),
+					'on-hold'       => __( 'On-hold', 'dintero-checkout-for-woocommerce' ),
 				),
 			),
 			/* Order Management */

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -64,7 +64,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	/**
 	 * Get the merchant reference.
 	 *
-	 * @param $order WC_Order
+	 * @param WC_Order $order The WooCommerce order.
 	 * @return string
 	 */
 	public function get_merchant_reference( $order ) {
@@ -345,7 +345,15 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			$shipping_line = array_values( $shipping_lines )[0];
 
 			// Retrieve the shipping id from the order object itself.
-			$shipping_id = get_post_meta( $this->order->get_id(), '_wc_dintero_shipping_id', true );
+			$shipping_id = $this->order->get_meta( '_wc_dintero_shipping_id' );
+
+			// WC_Order_Refund do not share the same meta data as WC_Order, and is thus missing the shipping id meta data.
+			if ( empty( $shipping_id ) ) {
+				$parent_order = wc_get_order( $this->order->get_parent_id() );
+				$shipping_id  = $parent_order->get_meta( '_wc_dintero_shipping_id' );
+			}
+
+			// If the shipping id is still missing, default to the shipping line data.
 			if ( empty( $shipping_id ) ) {
 				$shipping_id = $shipping_line->get_method_id() . ':' . $shipping_line->get_instance_id();
 			}

--- a/classes/requests/post/class-dintero-checkout-refund-order.php
+++ b/classes/requests/post/class-dintero-checkout-refund-order.php
@@ -50,10 +50,10 @@ class Dintero_Checkout_Refund_Order extends Dintero_Checkout_Request_Post {
 		}
 
 		return array(
-			'capture_reference' => strval( $this->arguments['order_id'] ),
-			'amount'            => $helper->get_order_total(),
-			'items'             => $order_lines,
-			'reason'            => $this->arguments['reason'],
+			'refund_reference' => strval( $this->arguments['order_id'] ),
+			'amount'           => $helper->get_order_total(),
+			'items'            => $order_lines,
+			'reason'           => $this->arguments['reason'],
 		);
 	}
 }

--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -5,12 +5,12 @@
  * Description: Dintero offers a complete payment solution. Simplifying the payment process for you and the customer.
  * Author: Dintero, Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.6.1
+ * Version: 1.7.0
  * Text Domain: dintero-checkout-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 6.1.0
- * WC tested up to: 7.9.0
+ * WC tested up to: 8.0.1
  *
  * Copyright (c) 2023 Krokedil
  *
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'DINTERO_CHECKOUT_VERSION', '1.6.1' );
+define( 'DINTERO_CHECKOUT_VERSION', '1.7.0' );
 define( 'DINTERO_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_MAIN_FILE', __FILE__ );
@@ -149,7 +149,7 @@ if ( ! class_exists( 'Dintero' ) ) {
 
 			add_action(
 				'widgets_init',
-				function() {
+				function () {
 					register_widget( 'Dintero_Checkout_Widget' );
 				}
 			);

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -53,10 +53,8 @@ function dintero_print_error_message( $wp_error ) {
 		if ( function_exists( 'wc_add_notice' ) ) {
 			$print = 'wc_add_notice';
 		}
-	} else {
-		if ( function_exists( 'wc_print_notice' ) ) {
+	} elseif ( function_exists( 'wc_print_notice' ) ) {
 			$print = 'wc_print_notice';
-		}
 	}
 
 	if ( ! isset( $print ) ) {
@@ -68,7 +66,7 @@ function dintero_print_error_message( $wp_error ) {
 		if ( is_array( $error ) ) {
 			$error   = array_filter(
 				$error,
-				function( $e ) {
+				function ( $e ) {
 					return ! empty( $e );
 				}
 			);
@@ -127,9 +125,10 @@ function dintero_update_wc_shipping( $data ) {
  */
 function dintero_confirm_order( $order, $transaction_id ) {
 	$order_id = $order->get_id();
+	$settings = get_option( 'woocommerce_dintero_checkout_settings' );
 
 	// Save the environment mode for use in the meta box.
-	$order->update_meta_data( '_wc_dintero_checkout_environment', 'yes' === get_option( 'woocommerce_dintero_checkout_settings' )['test_mode'] ? 'Test' : 'Production' );
+	$order->update_meta_data( '_wc_dintero_checkout_environment', 'yes' === $settings['test_mode'] ? 'Test' : 'Production' );
 
 	$order->update_meta_data( '_dintero_transaction_id', $transaction_id );
 	$dintero_order         = Dintero()->api->get_order( $transaction_id );
@@ -137,8 +136,11 @@ function dintero_confirm_order( $order, $transaction_id ) {
 	if ( $require_authorization ) {
 		$order->set_transaction_id( $transaction_id );
 		$order->update_meta_data( Dintero()->order_management->status( 'on_hold' ), $transaction_id );
+
+		$default_pending_authorization = $settings['order_status_pending_authorization'] ?? 'manual-review';
+
 		// translators: %s the Dintero transaction ID.
-		$order->update_status( 'manual-review', sprintf( __( 'The order was placed successfully, but requires further authorization by Dintero. Transaction ID: %s', 'dintero-checkout-for-woocommerce' ), $transaction_id ) );
+		$order->update_status( $default_pending_authorization, sprintf( __( 'The order was placed successfully, but requires further authorization by Dintero. Transaction ID: %s', 'dintero-checkout-for-woocommerce' ), $transaction_id ) );
 		Dintero_Checkout_Logger::log( "REDIRECT: The WC order $order_id (transaction ID: $transaction_id) will require further authorization from Dintero." );
 	} else {
 		// Check if the order has already been processed.
@@ -154,10 +156,10 @@ function dintero_confirm_order( $order, $transaction_id ) {
 			$order->add_order_note( sprintf( __( 'The order was placed successfully via Dintero Checkout. Transaction ID: %s', 'dintero-checkout-for-woocommerce' ), $transaction_id ) );
 		}
 
-		$default_status = get_option( 'woocommerce_dintero_checkout_settings' )['order_statuses'];
-		if ( 'processing' !== $default_status ) {
+		$default_status_authorized = $settings['order_status_authorized'] ?? 'processing';
+		if ( 'processing' !== $default_status_authorized ) {
 			$order->set_transaction_id( $transaction_id );
-			$order->set_status( $default_status );
+			$order->set_status( $default_status_authorized );
 			if ( ! $order->get_date_paid( 'edit' ) ) {
 				$order->set_date_paid( time() );
 			}

--- a/languages/dintero-checkout-for-woocommerce.pot
+++ b/languages/dintero-checkout-for-woocommerce.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/Dintero.Checkout.WooCommerce.V2\n"
-"POT-Creation-Date: 2023-08-28 08:45:19+00:00\n"
+"POT-Creation-Date: 2023-09-20 13:14:32+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -304,19 +304,19 @@ msgid "Choose your payment method in our checkout."
 msgstr ""
 
 #: classes/class-dintero-checkout-settings-fields.php:142
-#: classes/class-dintero-checkout-settings-fields.php:242
+#: classes/class-dintero-checkout-settings-fields.php:251
 msgid "Logo color"
 msgstr ""
 
 #: classes/class-dintero-checkout-settings-fields.php:144
-#: classes/class-dintero-checkout-settings-fields.php:245
-#: classes/class-dintero-checkout-settings-fields.php:255
+#: classes/class-dintero-checkout-settings-fields.php:254
+#: classes/class-dintero-checkout-settings-fields.php:264
 msgid "Default color"
 msgstr ""
 
 #: classes/class-dintero-checkout-settings-fields.php:148
-#: classes/class-dintero-checkout-settings-fields.php:248
-#: classes/class-dintero-checkout-settings-fields.php:258
+#: classes/class-dintero-checkout-settings-fields.php:257
+#: classes/class-dintero-checkout-settings-fields.php:267
 msgid "Custom color (HEX)"
 msgstr ""
 
@@ -344,62 +344,67 @@ msgid "Processing"
 msgstr ""
 
 #: classes/class-dintero-checkout-settings-fields.php:170
+#: classes/class-dintero-checkout-settings-fields.php:179
 msgid "On-hold"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:175
+#: classes/class-dintero-checkout-settings-fields.php:178
+msgid "Manual review"
+msgstr ""
+
+#: classes/class-dintero-checkout-settings-fields.php:184
 msgid "Order Management"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:179
+#: classes/class-dintero-checkout-settings-fields.php:188
 msgid "Refund by changing order status"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:180
+#: classes/class-dintero-checkout-settings-fields.php:189
 msgid ""
 "Trigger refund in Dintero when WooCommerce order status is manually changed "
 "to <u>Refunded</u>."
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:186
+#: classes/class-dintero-checkout-settings-fields.php:195
 msgid "Dintero Checkout Express Settings"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:190
+#: classes/class-dintero-checkout-settings-fields.php:199
 msgid "Allowed customer types"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:194
+#: classes/class-dintero-checkout-settings-fields.php:203
 msgid "Consumers and businesses"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:195
+#: classes/class-dintero-checkout-settings-fields.php:204
 msgid "Business only"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:196
+#: classes/class-dintero-checkout-settings-fields.php:205
 msgid "Consumer only"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:200
+#: classes/class-dintero-checkout-settings-fields.php:209
 msgid "Display Shipping in the iframe"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:203
+#: classes/class-dintero-checkout-settings-fields.php:212
 msgid "Enable"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:204
+#: classes/class-dintero-checkout-settings-fields.php:213
 msgid ""
 "Will make the shipping selection happen in the Dintero checkout iframe "
 "instead of the shipping section in WooCommerce."
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:238
+#: classes/class-dintero-checkout-settings-fields.php:247
 msgid "Branding"
 msgstr ""
 
-#: classes/class-dintero-checkout-settings-fields.php:252
+#: classes/class-dintero-checkout-settings-fields.php:261
 msgid "Footer background color"
 msgstr ""
 
@@ -425,7 +430,7 @@ msgstr ""
 
 #: classes/requests/helpers/class-dintero-checkout-cart.php:293
 #: classes/requests/helpers/class-dintero-checkout-cart.php:316
-#: classes/requests/helpers/class-dintero-checkout-order.php:248
+#: classes/requests/helpers/class-dintero-checkout-order.php:263
 msgid "Gift card"
 msgstr ""
 
@@ -436,6 +441,12 @@ msgstr ""
 #: classes/requests/helpers/class-dintero-checkout-helper-base.php:96
 #: classes/requests/helpers/class-dintero-checkout-helper-base.php:129
 msgid "Rounding fee"
+msgstr ""
+
+#: classes/requests/helpers/class-dintero-checkout-order.php:156
+msgid ""
+"This order contain a product that was permanently deleted. Cannot proceed "
+"with action."
 msgstr ""
 
 #: dintero-checkout-for-woocommerce.php:78
@@ -451,18 +462,18 @@ msgstr ""
 msgid "Select another payment method"
 msgstr ""
 
-#: includes/dintero-checkout-functions.php:141
+#: includes/dintero-checkout-functions.php:143
 #. translators: %s the Dintero transaction ID.
 msgid ""
 "The order was placed successfully, but requires further authorization by "
 "Dintero. Transaction ID: %s"
 msgstr ""
 
-#: includes/dintero-checkout-functions.php:151
+#: includes/dintero-checkout-functions.php:153
 msgid "The order has been authorized."
 msgstr ""
 
-#: includes/dintero-checkout-functions.php:154
+#: includes/dintero-checkout-functions.php:156
 #. translators: %s the Dintero transaction ID.
 msgid "The order was placed successfully via Dintero Checkout. Transaction ID: %s"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 5.8.3
 Tested up to: 6.3.0
 Requires PHP: 7.0
 WC requires at least: 6.1.0
-WC tested up to: 7.9.0
-Stable tag: 1.6.1
+WC tested up to: 8.0.1
+Stable tag: 1.7.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,11 @@ Go to [https://www.dintero.com/contact-us](https://www.dintero.com/contact-us) t
 1. The plugin settings screen where you set up the details to connect to Dintero.
 
 == Changelog ==
+= 2023.09.20    - version 1.7.0 =
+* Feature       - You can now set the default order status for orders pending authorization to "on-hold". Defaults to "manual-review".
+* Fix           - An attempt to capture order that contain a product that has been permanently removed will now fail without causing an critical error.
+* Fix           - Fixed an issue where a refund would fail due to missing order metadata, and the default shipping line data would be used instead of the one stored in the parent order.
+
 = 2023.08.28    - version 1.6.1 =
 * Fix           - Fixed an issue where you could no longer cancel an on-hold orders if the default order status was set to on-hold for not yet authorized orders.
 * Fix           - Fixed an issue where orders pending authorization were locked even after being authorized.


### PR DESCRIPTION
* Feature       - You can now set the default order status for orders pending authorization to "on-hold". Defaults to "manual-review".
* Fix           - An attempt to capture order that contain a product that has been permanently removed will now fail without causing an critical error.
* Fix           - Fixed an issue where a refund would fail due to missing order metadata, and the default shipping line data would be used instead of the one stored in the parent order.