### PR TITLE
Manually update customer object on input

### DIFF
--- a/classes/class-dintero-checkout-embedded.php
+++ b/classes/class-dintero-checkout-embedded.php
@@ -23,6 +23,42 @@ class Dintero_Checkout_Embedded {
 			add_filter( 'woocommerce_checkout_fields', array( $this, 'add_shipping_data_input' ) );
 			add_action( 'woocommerce_before_calculate_totals', array( $this, 'update_shipping_method' ), 1 );
 			add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_dintero_checkout_session' ), 9999 );
+			add_action( 'woocommerce_checkout_update_order_review', array( $this, 'update_wc_customer' ) );
+		}
+	}
+
+	/**
+	 * Update the WC_Customer with the entered billing and shipping data.
+	 *
+	 * By default, only the fields required for calculating shipping are updated.
+	 *
+	 * @param  string $raw_post_data The checkout form data.
+	 * @return void
+	 */
+	public function update_wc_customer( $raw_post_data ) {
+		parse_str( $raw_post_data, $post_data );
+		$post_data = array_filter(
+			wc_clean( wp_unslash( $post_data ) ),
+			function ( $value ) {
+				return ! empty( $value );
+			}
+		);
+
+		isset( $post_data['billing_first_name'] ) && WC()->customer->set_billing_first_name( $post_data['billing_first_name'] );
+		isset( $post_data['billing_last_name'] ) && WC()->customer->set_billing_last_name( $post_data['billing_last_name'] );
+		isset( $post_data['billing_company'] ) && WC()->customer->set_billing_company( $post_data['billing_company'] );
+		isset( $post_data['billing_phone'] ) && WC()->customer->set_billing_phone( $post_data['billing_phone'] );
+		isset( $post_data['billing_email'] ) && WC()->customer->set_billing_email( $post_data['billing_email'] );
+
+		if ( isset( $post_data['ship_to_different_address'] ) ) {
+			isset( $post_data['shipping_first_name'] ) && WC()->customer->set_shipping_first_name( $post_data['shipping_first_name'] );
+			isset( $post_data['shipping_last_name'] ) && WC()->customer->set_shipping_last_name( $post_data['shipping_last_name'] );
+			isset( $post_data['shipping_company'] ) && WC()->customer->set_shipping_company( $post_data['shipping_company'] );
+
+			// Since WC 5.6.0.
+			if ( method_exists( WC()->customer, 'set_shipping_phone' ) && isset( $post_data['shipping_phone'] ) ) {
+				WC()->customer->set_shipping_phone( $post_data['shipping_phone'] );
+			}
 		}
 	}
 
@@ -126,5 +162,5 @@ class Dintero_Checkout_Embedded {
 
 		Dintero()->api->update_checkout_session( $session_id );
 	}
-
-} new Dintero_Checkout_Embedded();
+}
+new Dintero_Checkout_Embedded();

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -357,7 +357,6 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 	 * @return array An associative array representing the billing address.
 	 */
 	public function get_billing_address() {
-
 		$billing_address = array(
 			'first_name'     => WC()->customer->get_billing_first_name(),
 			'last_name'      => WC()->customer->get_billing_last_name(),
@@ -374,8 +373,8 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 		/* Sanitize all values. Remove all empty elements (required by Dintero). */
 		return array_filter(
 			$billing_address,
-			function( $value ) {
-				return ! empty( sanitize_text_field( $value ) );
+			function ( $value ) {
+				return ! empty( wc_clean( $value ) );
 			}
 		);
 	}
@@ -405,8 +404,8 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 		/* Sanitize all values. Remove all empty elements (required by Dintero). */
 		return array_filter(
 			$shipping_address,
-			function( $value ) {
-				return ! empty( sanitize_text_field( $value ) );
+			function ( $value ) {
+				return ! empty( wc_clean( $value ) );
 			}
 		);
 	}

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -426,7 +426,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 		return array_filter(
 			$billing_address,
 			function ( $value ) {
-				return ! empty( sanitize_text_field( $value ) );
+				return ! empty( wc_clean( $value ) );
 			}
 		);
 	}
@@ -458,7 +458,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 		return array_filter(
 			$shipping_address,
 			function ( $value ) {
-				return ! empty( sanitize_text_field( $value ) );
+				return ! empty( wc_clean( $value ) );
 			}
 		);
 	}

--- a/classes/requests/put/class-dintero-checkout-update-checkout-session.php
+++ b/classes/requests/put/class-dintero-checkout-update-checkout-session.php
@@ -53,6 +53,19 @@ class Dintero_Checkout_Update_Checkout_Session extends Dintero_Checkout_Request_
 			'remove_lock' => true,
 		);
 
+		// Only non-express checkout must be updated through API since the fields are entered in WC.
+		if ( 'checkout' === $this->settings['checkout_type'] ) {
+			$billing_address = $helper->get_billing_address();
+			if ( ! empty( $billing_address ) ) {
+				$body['order']['billing_address'] = $billing_address;
+			}
+
+			$shipping_address = $helper->get_shipping_address();
+			if ( ! empty( $shipping_address ) ) {
+				$body['order']['shipping_address'] = $shipping_address;
+			}
+		}
+
 		// Set if express or not.
 		if ( $this->is_express() && $this->is_embedded() ) {
 			$this->add_express_object( $body );


### PR DESCRIPTION
Update the `WC_Customer` with the entered billing and shipping data. By default, only the fields required for calculating shipping are updated.

Related task: https://app.clickup.com/t/865d4dzer