### PR TITLE
Add support for custom shipping setups and several packages

### DIFF
--- a/classes/class-dintero-checkout-settings-fields.php
+++ b/classes/class-dintero-checkout-settings-fields.php
@@ -218,16 +218,15 @@ class Dintero_Settings_Fields {
 				'label'    => __( 'Enable', 'dintero-checkout-for-woocommerce' ),
 				'desc_tip' => __( 'Will make the shipping selection happen in the Dintero checkout iframe instead of the shipping section in WooCommerce.', 'dintero-checkout-for-woocommerce' ),
 			),
-
-			/*
-			TODO: These options will be added in a future iteration.
 			'express_show_shipping'                   => array(
 				'title'    => __( 'Show shipping info in Express', 'dintero-checkout-for-woocommerce' ),
 				'type'     => 'checkbox',
-				'default'  => 'no',
+				'default'  => 'yes',
 				'label'    => __( 'Enable', 'dintero-checkout-for-woocommerce' ),
-				'desc_tip' => __( 'Disable if you sell digital products.', 'dintero-checkout-for-woocommerce' ),
+				'desc_tip' => __( 'Disable if you sell digital products or handle shipping outside Dintero.', 'dintero-checkout-for-woocommerce' ),
 			),
+			/*
+			TODO: These options will be added in a future iteration.
 			'express_show_product_button'             => array(
 				'title'   => __( 'Show Express button on product page', 'dintero-checkout-for-woocommerce' ),
 				'type'    => 'checkbox',

--- a/classes/requests/class-dintero-checkout-request.php
+++ b/classes/requests/class-dintero-checkout-request.php
@@ -259,4 +259,17 @@ abstract class Dintero_Checkout_Request {
 
 		return true;
 	}
+
+	/**
+	 * Returns if express shipping should be shown.
+	 *
+	 * @return boolean
+	 */
+	public function show_express_shipping() {
+		if ( 'no' === $this->settings['express_show_shipping'] ) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -193,13 +193,16 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 	public function get_shipping_items() {
 		$shipping_options = array();
 
-		$shipping_ids   = array_unique( WC()->session->get( 'chosen_shipping_methods' ) );
-		$shipping_rates = WC()->shipping->get_packages()[0]['rates'];
+        $chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
+        $shipping_packages =  WC()->shipping->get_packages();
 
-		foreach ( $shipping_ids as  $shipping_id ) {
-			$shipping_method    = $shipping_rates[ $shipping_id ];
+        foreach ( $shipping_packages as $package_index => $package ) {
+			$available_methods = $package['rates'];
+			$chosen_method_id  = $chosen_shipping_methods[ $package_index ];
+
+			$shipping_method = $available_methods[ $chosen_method_id ];
 			$shipping_options[] = $this->get_shipping_item( $shipping_method );
-		}
+        }
 
 		return $shipping_options;
 	}

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -194,16 +194,16 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 	public function get_shipping_items() {
 		$shipping_options = array();
 
-        $chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
-        $shipping_packages =  WC()->shipping->get_packages();
+		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
+		$shipping_packages       = WC()->shipping->get_packages();
 
-        foreach ( $shipping_packages as $package_index => $package ) {
+		foreach ( $shipping_packages as $package_index => $package ) {
 			$available_methods = $package['rates'];
 			$chosen_method_id  = $chosen_shipping_methods[ $package_index ];
 
-			$shipping_method = $available_methods[ $chosen_method_id ];
+			$shipping_method    = $available_methods[ $chosen_method_id ];
 			$shipping_options[] = $this->get_shipping_item( $shipping_method );
-        }
+		}
 
 		return $shipping_options;
 	}
@@ -256,16 +256,20 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 	 * @return array
 	 */
 	public function get_shipping_item( $shipping_method ) {
-		return apply_filters( 'dintero_checkout_shipping_item', array(
-			'id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
-			'line_id'    => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
-			'amount'     => self::format_number( $shipping_method->get_cost() + $shipping_method->get_shipping_tax() ),
-			'title'      => $shipping_method->get_label(),
-			'vat_amount' => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() ),
-			'vat'        => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() / $shipping_method->get_cost() ),
-			'quantity'   => 1,
-			'type'       => 'shipping',
-		), $shipping_method );
+		return apply_filters(
+			'dintero_checkout_shipping_item',
+			array(
+				'id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
+				'line_id'    => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
+				'amount'     => self::format_number( $shipping_method->get_cost() + $shipping_method->get_shipping_tax() ),
+				'title'      => $shipping_method->get_label(),
+				'vat_amount' => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() ),
+				'vat'        => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() / $shipping_method->get_cost() ),
+				'quantity'   => 1,
+				'type'       => 'shipping',
+			),
+			$shipping_method
+		);
 	}
 
 	/**

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -52,9 +52,10 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 	/**
 	 * Gets formatted cart items.
 	 *
+	 * @param bool $include_all_shipping_lines Whether to include all shipping lines or not
 	 * @return array Formatted cart items.
 	 */
-	public function get_order_lines() {
+	public function get_order_lines( $include_all_shipping_lines = false ) {
 		$cart = WC()->cart->get_cart();
 
 		// Get cart items.
@@ -73,7 +74,7 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 		}
 
 		// Get cart shipping.
-		if ( WC()->cart->needs_shipping() && count( WC()->shipping->get_packages() ) > 1 ) {
+		if ( WC()->cart->needs_shipping() && ( $include_all_shipping_lines || count( WC()->shipping->get_packages() ) > 1 ) ) {
 			// Handle multiple shipping lines.
 			$formatted_cart_items = array_merge( $formatted_cart_items, $this->get_shipping_items() );
 		}

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -256,8 +256,8 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 	 */
 	public function get_shipping_item( $shipping_method ) {
 		return array(
-			'id'         => $shipping_method->get_id(),
-			'line_id'    => $shipping_method->get_id(),
+			'id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
+			'line_id'    => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
 			'amount'     => self::format_number( $shipping_method->get_cost() + $shipping_method->get_shipping_tax() ),
 			'title'      => $shipping_method->get_label(),
 			'vat_amount' => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() ),

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -251,7 +251,7 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 	/**
 	 * Formats the shipping method to be used in order.items.
 	 *
-	 * @param WC_Shipping_rate $shipping_method The WooCommerce shipping method.
+	 * @param WC_Shipping_Rate $shipping_method The WooCommerce shipping method.
 	 * @return array
 	 */
 	public function get_shipping_item( $shipping_method ) {

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -255,7 +255,7 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 	 * @return array
 	 */
 	public function get_shipping_item( $shipping_method ) {
-		return array(
+		return apply_filters( 'dintero_checkout_shipping_item', array(
 			'id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
 			'line_id'    => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
 			'amount'     => self::format_number( $shipping_method->get_cost() + $shipping_method->get_shipping_tax() ),
@@ -264,7 +264,7 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 			'vat'        => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() / $shipping_method->get_cost() ),
 			'quantity'   => 1,
 			'type'       => 'shipping',
-		);
+		), $shipping_method );
 	}
 
 	/**

--- a/classes/requests/helpers/class-dintero-checkout-helper-base.php
+++ b/classes/requests/helpers/class-dintero-checkout-helper-base.php
@@ -44,9 +44,10 @@ abstract class Dintero_Checkout_Helper_Base {
 	 * @param bool                                         $is_embedded If the request is for an embedded checkout.
 	 * @param bool                                         $is_express If the request is for an express checkout.
 	 * @param bool                                         $is_shipping_in_iframe If the request is for shipping selections in the iframe.
+	 * @param bool                                         $show_express_shipping If we should show shipping options in express checkout.
 	 * @return void
 	 */
-	public static function add_shipping( &$body, $helper, $is_embedded, $is_express, $is_shipping_in_iframe ) {
+	public static function add_shipping( &$body, $helper, $is_embedded, $is_express, $is_shipping_in_iframe, $show_express_shipping ) {
 		// We will always need this if shipping is available, so it will always be added.
 		$shipping_option = $helper->get_shipping_option();
 		if ( ! empty( $shipping_option ) ) {
@@ -56,7 +57,7 @@ abstract class Dintero_Checkout_Helper_Base {
 		// If its express we need to add the express options.
 		if ( $is_embedded && $is_express ) {
 			// If the cart does not need shipping, unset shipping, set empty array and shipping_not_required.
-			if ( ! WC()->cart->needs_shipping() ) {
+			if ( ! $show_express_shipping || ! WC()->cart->needs_shipping() ) {
 				unset( $body['order']['shipping_option'] );
 				$body['express']['shipping_options'] = array();
 				$body['express']['shipping_mode']    = 'shipping_not_required';

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -272,7 +272,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	/**
 	 * Formats the shipping method to be used in order.items.
 	 *
-	 * @param WC_Shipping_rate $shipping_method The shipping method from WooCommerce.
+	 * @param WC_Shipping_Rate $shipping_method The shipping method from WooCommerce.
 	 * @return array
 	 */
 	public function get_shipping_item( $shipping_method ) {

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -276,7 +276,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	 * @return array
 	 */
 	public function get_shipping_item( $shipping_method ) {
-		return array(
+		return apply_filters( 'dintero_checkout_shipping_item', array(
 			/* NOTE: The id and line_id must match the same id and line_id on capture and refund. */
 			'id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
 			'line_id'    => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
@@ -288,7 +288,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			'quantity'   => 1,
 			/* Dintero needs to know this is an order with multiple shipping options by setting the 'type'. */
 			'type'       => 'shipping',
-		);
+		). $shipping_method );
 	}
 
 	/**
@@ -315,7 +315,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			return array();
 		}
 
-		return array(
+		return apply_filters('dintero_checkout_shipping_option', array(
 			/* NOTE: The id and line_id must match the same id and line_id on capture and refund. */
 			'id'              => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
 			'line_id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
@@ -326,7 +326,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			'delivery_method' => 'unspecified',
 			'vat_amount'      => self::format_number( $shipping_method->get_total_tax() ),
 			'vat'             => ( empty( floatval( $shipping_method->get_total() ) ) ) ? 0 : self::format_number( $shipping_method->get_total_tax() / $shipping_method->get_total() ),
-		);
+		), $shipping_method );
 	}
 
 	/**
@@ -358,7 +358,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 				$shipping_id = $shipping_line->get_method_id() . ':' . $shipping_line->get_instance_id();
 			}
 
-			return array(
+			return apply_filters('dintero_checkout_shipping_option', array(
 				'id'          => $shipping_id,
 				'line_id'     => $shipping_id,
 				'amount'      => absint( self::format_number( $shipping_line->get_total() + $shipping_line->get_total_tax() ) ),
@@ -367,7 +367,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 				'title'       => $shipping_line->get_method_title(),
 				'vat_amount'  => self::format_number( $shipping_line->get_total_tax() ),
 				'vat'         => ( ! empty( floatval( $shipping_line->get_total() ) ) ) ? self::format_number( $shipping_line->get_total_tax() / $shipping_line->get_total() ) : 0,
-			);
+			), $shipping_line );
 		}
 		return null;
 	}

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -74,9 +74,10 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	/**
 	 * Gets formatted cart items.
 	 *
+	 * @param bool $include_all_shipping_lines Whether to include all shipping lines or not
 	 * @return array Formatted cart items.
 	 */
-	public function get_order_lines() {
+	public function get_order_lines( $include_all_shipping_lines = false ) {
 		$order_lines = array();
 
 		/**
@@ -96,7 +97,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 		 *
 		 * @var WC_Order_Item_Shipping $order_item WooCommerce order item shipping.
 		 */
-		if ( count( $this->order->get_items( 'shipping' ) ) > 1 ) {
+		if ( $include_all_shipping_lines || count( $this->order->get_items( 'shipping' ) ) > 1 ) {
 			/* If there is more than one shipping option, it will be part of the order.items to support multiple shipping packages. */
 			foreach ( $this->order->get_items( 'shipping' ) as $order_item ) {
 				$order_line = $this->get_shipping_option( $order_item );

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -277,19 +277,22 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	 * @return array
 	 */
 	public function get_shipping_item( $shipping_method ) {
-		return apply_filters( 'dintero_checkout_shipping_item', array(
-			/* NOTE: The id and line_id must match the same id and line_id on capture and refund. */
-			'id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
-			'line_id'    => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
-			'amount'     => self::format_number( $shipping_method->get_cost() + $shipping_method->get_shipping_tax() ),
-			'title'      => $shipping_method->get_label(),
-			'vat_amount' => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() ),
-			'vat'        => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() / $shipping_method->get_cost() ),
-			/* Since the shipping will be added to the list of products, it needs a quantity. */
-			'quantity'   => 1,
-			/* Dintero needs to know this is an order with multiple shipping options by setting the 'type'. */
-			'type'       => 'shipping',
-		). $shipping_method );
+		return apply_filters(
+			'dintero_checkout_shipping_item',
+			array(
+				/* NOTE: The id and line_id must match the same id and line_id on capture and refund. */
+				'id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
+				'line_id'    => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
+				'amount'     => self::format_number( $shipping_method->get_cost() + $shipping_method->get_shipping_tax() ),
+				'title'      => $shipping_method->get_label(),
+				'vat_amount' => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() ),
+				'vat'        => ( empty( floatval( $shipping_method->get_cost() ) ) ) ? 0 : self::format_number( $shipping_method->get_shipping_tax() / $shipping_method->get_cost() ),
+				/* Since the shipping will be added to the list of products, it needs a quantity. */
+				'quantity'   => 1,
+				/* Dintero needs to know this is an order with multiple shipping options by setting the 'type'. */
+				'type'       => 'shipping',
+			) . $shipping_method
+		);
 	}
 
 	/**
@@ -316,18 +319,22 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			return array();
 		}
 
-		return apply_filters('dintero_checkout_shipping_option', array(
-			/* NOTE: The id and line_id must match the same id and line_id on capture and refund. */
-			'id'              => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
-			'line_id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
-			'amount'          => self::format_number( $shipping_method->get_total() + $shipping_method->get_total_tax() ),
-			'operator'        => '',
-			'description'     => '',
-			'title'           => $shipping_method->get_method_title(),
-			'delivery_method' => 'unspecified',
-			'vat_amount'      => self::format_number( $shipping_method->get_total_tax() ),
-			'vat'             => ( empty( floatval( $shipping_method->get_total() ) ) ) ? 0 : self::format_number( $shipping_method->get_total_tax() / $shipping_method->get_total() ),
-		), $shipping_method );
+		return apply_filters(
+			'dintero_checkout_shipping_option',
+			array(
+				/* NOTE: The id and line_id must match the same id and line_id on capture and refund. */
+				'id'              => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
+				'line_id'         => $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
+				'amount'          => self::format_number( $shipping_method->get_total() + $shipping_method->get_total_tax() ),
+				'operator'        => '',
+				'description'     => '',
+				'title'           => $shipping_method->get_method_title(),
+				'delivery_method' => 'unspecified',
+				'vat_amount'      => self::format_number( $shipping_method->get_total_tax() ),
+				'vat'             => ( empty( floatval( $shipping_method->get_total() ) ) ) ? 0 : self::format_number( $shipping_method->get_total_tax() / $shipping_method->get_total() ),
+			),
+			$shipping_method
+		);
 	}
 
 	/**
@@ -359,16 +366,20 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 				$shipping_id = $shipping_line->get_method_id() . ':' . $shipping_line->get_instance_id();
 			}
 
-			return apply_filters('dintero_checkout_shipping_option', array(
-				'id'          => $shipping_id,
-				'line_id'     => $shipping_id,
-				'amount'      => absint( self::format_number( $shipping_line->get_total() + $shipping_line->get_total_tax() ) ),
-				'operator'    => '',
-				'description' => '',
-				'title'       => $shipping_line->get_method_title(),
-				'vat_amount'  => self::format_number( $shipping_line->get_total_tax() ),
-				'vat'         => ( ! empty( floatval( $shipping_line->get_total() ) ) ) ? self::format_number( $shipping_line->get_total_tax() / $shipping_line->get_total() ) : 0,
-			), $shipping_line );
+			return apply_filters(
+				'dintero_checkout_shipping_option',
+				array(
+					'id'          => $shipping_id,
+					'line_id'     => $shipping_id,
+					'amount'      => absint( self::format_number( $shipping_line->get_total() + $shipping_line->get_total_tax() ) ),
+					'operator'    => '',
+					'description' => '',
+					'title'       => $shipping_line->get_method_title(),
+					'vat_amount'  => self::format_number( $shipping_line->get_total_tax() ),
+					'vat'         => ( ! empty( floatval( $shipping_line->get_total() ) ) ) ? self::format_number( $shipping_line->get_total_tax() / $shipping_line->get_total() ) : 0,
+				),
+				$shipping_line
+			);
 		}
 		return null;
 	}

--- a/classes/requests/post/class-dintero-checkout-capture-order.php
+++ b/classes/requests/post/class-dintero-checkout-capture-order.php
@@ -42,8 +42,8 @@ class Dintero_Checkout_Capture_Order extends Dintero_Checkout_Request_Post {
 	public function get_body() {
 		$helper = new Dintero_Checkout_Order( $this->arguments['order_id'] );
 
-		$order_lines = $helper->get_order_lines();
-		$shipping    = $helper->get_shipping_object();
+		$order_lines = $helper->get_order_lines( ! $this->show_express_shipping() );
+		$shipping    = $this->show_express_shipping() ? $helper->get_shipping_object() : null;
 
 		if ( ! empty( $shipping ) ) {
 			$order_lines[] = $helper::format_shipping_for_om( $shipping );

--- a/classes/requests/post/class-dintero-checkout-create-session.php
+++ b/classes/requests/post/class-dintero-checkout-create-session.php
@@ -67,7 +67,7 @@ class Dintero_Checkout_Create_Session extends Dintero_Checkout_Request_Post {
 				'currency'           => $helper->get_currency(),
 				'merchant_reference' => $reference,
 				'vat_amount'         => $helper->get_tax_total(),
-				'items'              => $helper->get_order_lines(),
+				'items'              => $helper->get_order_lines( ! $this->show_express_shipping() ),
 				'store'              => array(
 					'id' => preg_replace( '/(https?:\/\/|www.|\/\s*$)/i', '', get_home_url() ),
 				),
@@ -94,7 +94,7 @@ class Dintero_Checkout_Create_Session extends Dintero_Checkout_Request_Post {
 			$this->add_express_object( $body );
 		}
 
-		$helper::add_shipping( $body, $helper, $this->is_embedded(), $this->is_express(), $this->is_shipping_in_iframe() );
+		$helper::add_shipping( $body, $helper, $this->is_embedded(), $this->is_express(), $this->is_shipping_in_iframe(), $this->show_express_shipping() );
 		$helper::add_rounding_line( $body );
 
 		return $body;

--- a/classes/requests/post/class-dintero-checkout-refund-order.php
+++ b/classes/requests/post/class-dintero-checkout-refund-order.php
@@ -42,8 +42,8 @@ class Dintero_Checkout_Refund_Order extends Dintero_Checkout_Request_Post {
 	public function get_body() {
 		$helper = new Dintero_Checkout_Order( $this->arguments['order_id'] );
 
-		$order_lines = $helper->get_order_lines();
-		$shipping    = $helper->get_shipping_object();
+		$order_lines = $helper->get_order_lines( ! $this->show_express_shipping() );
+		$shipping    = $this->show_express_shipping() ? $helper->get_shipping_object() : null;
 
 		if ( ! empty( $shipping ) ) {
 			$order_lines[] = $helper::format_shipping_for_om( $shipping );

--- a/classes/requests/put/class-dintero-checkout-update-checkout-session.php
+++ b/classes/requests/put/class-dintero-checkout-update-checkout-session.php
@@ -45,7 +45,7 @@ class Dintero_Checkout_Update_Checkout_Session extends Dintero_Checkout_Request_
 				'amount'     => $helper->get_order_total(),
 				'currency'   => $helper->get_currency(),
 				'vat_amount' => $helper->get_tax_total(),
-				'items'      => $helper->get_order_lines(),
+				'items'      => $helper->get_order_lines( ! $this->show_express_shipping() ),
 				'store'      => array(
 					'id' => preg_replace( '/(https?:\/\/|www.|\/\s*$)/i', '', get_home_url() ),
 				),
@@ -71,7 +71,7 @@ class Dintero_Checkout_Update_Checkout_Session extends Dintero_Checkout_Request_
 			$this->add_express_object( $body );
 		}
 
-		$helper::add_shipping( $body, $helper, $this->is_embedded(), $this->is_express(), $this->is_shipping_in_iframe() );
+		$helper::add_shipping( $body, $helper, $this->is_embedded(), $this->is_express(), $this->is_shipping_in_iframe(), $this->show_express_shipping() );
 		$helper::add_rounding_line( $body );
 
 		return $body;


### PR DESCRIPTION
Hi,

We are running a Dokan setup with support for multi-vendor orders and multiple shipping packages. To make that work with Dintero we have had to make some changes to this great plugin:

1. Make it possible to disable shipping handling inside express checkout (we want to handle it completely on our end).
2. Add support for multiple shipping packages (not making the assumption its just one).
3. Add filter to make it possible to override shipping line items and options.

PS: Its not unlikely that there are some bugs lurking since we have only tested it for our use-case with embedded express checkout.