### PR TITLE
Add a max diff when verifying order total

### DIFF
--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -536,7 +536,8 @@ jQuery( function ( $ ) {
                     nonce: dinteroCheckoutParams.verifyOrderTotalNonce,
                 },
                 dataType: "json",
-                success: ( data ) => {
+                success: (data) => {
+                    console.log('order total diff: %s', data.data)
                     if ( ! data.success ) {
                         dinteroCheckoutForWooCommerce.failOrder(
                             "submit order failed",

--- a/classes/class-dintero-checkout-ajax.php
+++ b/classes/class-dintero-checkout-ajax.php
@@ -135,14 +135,17 @@ class Dintero_Checkout_Ajax extends WC_AJAX {
 		$id      = filter_input( INPUT_POST, 'id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$session = Dintero()->api->get_session( $id );
 
+		WC()->cart->calculate_totals();
 		$total    = $session['order']['amount'];
 		$wc_total = intval( WC()->cart->total * 100 );
 
-		if ( $total === $wc_total ) {
-			wp_send_json_success( $total - $wc_total );
+		$max_diff = 10; // minor units.
+		$diff     = $total - $wc_total;
+		if ( $max_diff > $diff ) {
+			wp_send_json_success( $diff );
 		}
 
-		wp_send_json_error( -absint( $total - $wc_total ) );
+		wp_send_json_error( $diff );
 	}
 }
 Dintero_Checkout_Ajax::init();


### PR DESCRIPTION
When verifying the order total, we check if the total in both systems matches exactly which can be problematic due to rounding errors.

- calculate WC totals.
- permit a difference of up to 10 minor units.
- log the difference to the browser console.