### PR TITLE
Account for manually refunded items in calculation

### DIFF
--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -136,10 +136,22 @@ class Dintero_Checkout_Order_Management {
 			}
 
 			if ( $response['amount'] > 0 ) {
+				// The last capture event is most likely the current capture event.
+				$event = array_filter(
+					array_reverse( $response['events'] ),
+					function ( $event ) {
+						return $event['event'] === 'CAPTURE';
+					}
+				);
+
+				// Since the amount in the response is the total amount, not the total captured amount. We need to get the amount from the last capture event.
+				$event  = reset( $event );
+				$amount = isset( $event['event'] ) ? $event['amount'] : $response['amount'];
+
 				$note = sprintf(
 					// translators: the amount, the currency.
 					__( 'The Dintero order has been captured. Captured amount: %1$.2f %2$s.', 'dintero-checkout-for-woocommerce' ),
-					substr_replace( $response['amount'], wc_get_price_decimal_separator(), -2, 0 ),
+					substr_replace( $amount, wc_get_price_decimal_separator(), -2, 0 ),
 					$response['currency']
 				);
 

--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -140,7 +140,7 @@ class Dintero_Checkout_Order_Management {
 				$event = array_filter(
 					array_reverse( $response['events'] ),
 					function ( $event ) {
-						return $event['event'] === 'CAPTURE';
+						return 'CAPTURE' === $event['event'];
 					}
 				);
 

--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -318,7 +318,29 @@ class Dintero_Checkout_Order_Management {
 		}
 
 		if ( $this->is_partially_refunded( $order_id ) ) {
-			$order->add_order_note( __( 'The Dintero order has been partially refunded.', 'dintero-checkout-for-woocommerce' ) );
+			// The last refund event is most likely the current refund event .
+			$event = array_filter(
+				array_reverse( $response['events'] ),
+				function ( $event ) {
+					return 'REFUND' === $event['event'];
+				}
+			);
+
+			// Since the amount in the response is the total order amount, not the refunded amount. We need to get the amount from the last refund event.
+			$event = reset( $event );
+			if ( isset( $event['event'] ) ) {
+				$amount = $event['amount'];
+				$note   = sprintf(
+				// translators: the amount, the currency.
+					__( 'The Dintero order has been partially refunded. Refunded amount: %1$.2f %2$s.', 'dintero-checkout-for-woocommerce' ),
+					substr_replace( $amount, wc_get_price_decimal_separator(), -2, 0 ),
+					$response['currency']
+				);
+			} else {
+				$note = __( 'The Dintero order has been partially refunded.', 'dintero-checkout-for-woocommerce' );
+			}
+
+			$order->add_order_note( $note );
 			$order->update_meta_data( $this->status['partially_refunded'], current_time( ' Y-m-d H:i:s' ) );
 
 		} else {

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -11,27 +11,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class for processing orders items to be used with order management.
  */
 class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
+
 	/**
 	 * The WooCommerce order.
 	 *
-	 * @var WC_Order
+	 * @var WC_Order|WC_Order_Refund
 	 */
 	public $order;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param int $order_id The WooCommerce order id.
+	 * @param WC_Order|WC_Order_Refund $order The Woo order.
 	 */
-	public function __construct( $order_id ) {
-		$order   = wc_get_order( $order_id );
-		$refunds = $order->get_refunds();
-
-		if ( count( $refunds ) > 0 ) {
-			$this->order = $refunds[0];
-		} else {
-			$this->order = $order;
-		}
+	public function __construct( $order ) {
+		$this->order = $order;
 	}
 
 	/**
@@ -40,7 +34,14 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	 * @return int
 	 */
 	public function get_order_total() {
-		return absint( self::format_number( $this->order->get_total() ) );
+		$order_total = self::format_number( $this->order->get_total() );
+		if ( $this->order instanceof WC_Order ) {
+			// Only available and relevant for WC_Order.
+			$refunded_total = self::format_number( $this->order->get_total_refunded() );
+			return absint( $order_total - $refunded_total );
+		}
+
+		return absint( $order_total );
 	}
 
 	/**
@@ -49,16 +50,24 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	 * @return int
 	 */
 	public function get_tax_total() {
-		return absint( self::format_number( $this->order->get_total_tax() ) );
+		$order_total_tax = self::format_number( $this->order->get_total_tax() );
+
+		if ( $this->order instanceof WC_Order ) {
+			// Only available and relevant for WC_Order.
+			$refunded_total_tax = self::format_number( $this->order->get_total_tax_refunded() );
+			return absint( $order_total_tax - $refunded_total_tax );
+		}
+
+		return absint( $order_total_tax );
 	}
 
 	/**
-	 * Get the cart currency.
+	 * Get the order currency.
 	 *
 	 * @return string
 	 */
 	public function get_currency() {
-		return get_woocommerce_currency();
+		return $this->order->get_currency();
 	}
 
 	/**
@@ -84,7 +93,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 		 *
 		 * @var WC_Order_Item_Product $order_item WooCommerce order item product.
 		 */
-		foreach ( $this->order->get_items() as $order_item ) {
+		foreach ( $this->get_items() as $order_item ) {
 			$order_line = $this->get_order_line( $order_item );
 			if ( ! empty( $order_line ) ) {
 				$order_lines[] = $order_line;
@@ -96,9 +105,10 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 		 *
 		 * @var WC_Order_Item_Shipping $order_item WooCommerce order item shipping.
 		 */
-		if ( count( $this->order->get_items( 'shipping' ) ) > 1 ) {
+		$shipping_items = $this->get_items( 'shipping' );
+		if ( count( $shipping_items ) > 1 ) {
 			/* If there is more than one shipping option, it will be part of the order.items to support multiple shipping packages. */
-			foreach ( $this->order->get_items( 'shipping' ) as $order_item ) {
+			foreach ( $shipping_items as $order_item ) {
 				$order_line = $this->get_shipping_option( $order_item );
 				if ( ! empty( $order_line ) ) {
 					$order_lines[] = $order_line;
@@ -141,13 +151,75 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	}
 
 	/**
+	 * Return an array of items/products within this order.
+	 *
+	 * Filters out any refunded items. This should ensure manual refunds are taken into consideration.
+	 *
+	 * @param string|array $types Types of line items to get (array or string).
+	 * @return WC_Order_Item[]
+	 */
+	private function get_items( $types = 'line_item' ) {
+		$order_items = $this->order->get_items( $types );
+
+		if ( $this->order instanceof WC_Order_Refund ) {
+			return $order_items;
+		}
+
+		if ( ! ( is_string( $types ) && in_array( $types, array( 'line_item', 'shipping' ), true ) ) ) {
+			return $order_items;
+		}
+
+		$refunds = $this->order->get_refunds();
+
+		// Retrieve all the items that has been refunded.
+		$refunded_order_items = array_reduce(
+			$refunds,
+			function ( $carry, $refund ) use ( $types ) {
+				$items = $refund->get_items( $types );
+				if ( ! empty( $items ) ) {
+					$carry = array_merge( $carry, $items );
+				}
+				return $carry;
+			},
+			array()
+		);
+
+		// Remove refunded items from the order items.
+		foreach ( $refunded_order_items as $refunded_order_item ) {
+			if ( $refunded_order_item instanceof WC_Order_Item_Product ) {
+				$refunded_product_id     = empty( $refunded_order_item['variation_id'] ) ? $refunded_order_item['product_id'] : $refunded_order_item['variation_id'];
+				$refunded_order_item_key = $this->get_product_sku( wc_get_product( $refunded_product_id ) );
+
+			} elseif ( $refunded_order_item instanceof WC_Order_Item_Shipping ) {
+				$refunded_order_item_key = $refunded_order_item->get_method_id() . ':' . $refunded_order_item->get_instance_id();
+			}
+
+			foreach ( $order_items as $i => $order_item ) {
+				if ( $order_item instanceof WC_Order_Item_Product ) {
+					$product_id     = empty( $order_item['variation_id'] ) ? $order_item['product_id'] : $order_item['variation_id'];
+					$order_item_key = $this->get_product_sku( wc_get_product( $product_id ) );
+
+				} elseif ( $order_item instanceof WC_Order_Item_Shipping ) {
+					$order_item_key = $order_item->get_method_id() . ':' . $order_item->get_instance_id();
+				}
+
+				if ( $refunded_order_item_key === $order_item_key ) {
+					unset( $order_items[ $i ] );
+				}
+			}
+		}
+
+		return $order_items;
+	}
+
+	/**
 	 * Get the formatted order line from a cart item.
 	 *
 	 * @param WC_Order_Item_Product $order_item WooCommerce order item product.
 	 * @return array
 	 */
 	public function get_order_line( $order_item ) {
-		$id      = ( empty( $order_item['variation_id'] ) ) ? $order_item['product_id'] : $order_item['variation_id'];
+		$id      = empty( $order_item['variation_id'] ) ? $order_item['product_id'] : $order_item['variation_id'];
 		$product = wc_get_product( $id );
 
 		// Check if the product has been permanently deleted.
@@ -299,13 +371,13 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	 */
 	public function get_shipping_option( $shipping_method = null ) {
 		if ( empty( $shipping_method ) ) {
-			if ( count( $this->order->get_items( 'shipping' ) ) === 1 ) {
+			if ( count( $this->get_items( 'shipping' ) ) === 1 ) {
 				/**
 				 * Process order item shipping.
 				 *
 				 * @var WC_Order_Item_Shipping $order_item WooCommerce order item shipping.
 				 */
-				foreach ( $this->order->get_items( 'shipping' ) as $order_item ) {
+				foreach ( $this->get_items( 'shipping' ) as $order_item ) {
 					$shipping_method = $order_item;
 				}
 			}
@@ -335,7 +407,8 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	 * @return array|null
 	 */
 	public function get_shipping_object() {
-		$shipping_lines = $this->order->get_items( 'shipping' );
+		$shipping_lines = $this->get_items( 'shipping' );
+
 		if ( count( $shipping_lines ) === 1 ) {
 			/**
 			 * Process the shipping line.
@@ -366,7 +439,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 				'description' => '',
 				'title'       => $shipping_line->get_method_title(),
 				'vat_amount'  => self::format_number( $shipping_line->get_total_tax() ),
-				'vat'         => ( ! empty( floatval( $shipping_line->get_total() ) ) ) ? self::format_number( $shipping_line->get_total_tax() / $shipping_line->get_total() ) : 0,
+				'vat'         => ! empty( floatval( $shipping_line->get_total() ) ) ? self::format_number( $shipping_line->get_total_tax() / $shipping_line->get_total() ) : 0,
 			);
 		}
 		return null;

--- a/classes/requests/post/class-dintero-checkout-capture-order.php
+++ b/classes/requests/post/class-dintero-checkout-capture-order.php
@@ -40,7 +40,8 @@ class Dintero_Checkout_Capture_Order extends Dintero_Checkout_Request_Post {
 	 * @return array
 	 */
 	public function get_body() {
-		$helper = new Dintero_Checkout_Order( $this->arguments['order_id'] );
+		$order  = wc_get_order( $this->arguments['order_id'] );
+		$helper = new Dintero_Checkout_Order( $order );
 
 		$order_lines = $helper->get_order_lines();
 		$shipping    = $helper->get_shipping_object();

--- a/classes/requests/post/class-dintero-checkout-create-session.php
+++ b/classes/requests/post/class-dintero-checkout-create-session.php
@@ -45,7 +45,7 @@ class Dintero_Checkout_Create_Session extends Dintero_Checkout_Request_Post {
 			$order_id = is_wc_endpoint_url( 'order-pay' ) ? wc_get_order_id_by_order_key( sanitize_key( $key ) ) : $this->arguments['order_id'];
 			$order    = wc_get_order( $order_id );
 
-			$helper = new Dintero_Checkout_Order( $order_id );
+			$helper = new Dintero_Checkout_Order( $order );
 		} else {
 			$helper = new Dintero_Checkout_Cart();
 		}

--- a/classes/requests/post/class-dintero-checkout-refund-order.php
+++ b/classes/requests/post/class-dintero-checkout-refund-order.php
@@ -40,7 +40,11 @@ class Dintero_Checkout_Refund_Order extends Dintero_Checkout_Request_Post {
 	 * @return array
 	 */
 	public function get_body() {
-		$helper = new Dintero_Checkout_Order( $this->arguments['order_id'] );
+		$order   = wc_get_order( $this->arguments['order_id'] );
+		$refunds = $order->get_refunds();
+		$order   = reset( $refunds );
+
+		$helper = new Dintero_Checkout_Order( $order );
 
 		$order_lines = $helper->get_order_lines();
 		$shipping    = $helper->get_shipping_object();


### PR DESCRIPTION
Woo keeps track of the manually refunded total separately from the gateway refunded total. This would result in capture request that do not account for the manual refund.

- account for manually refunded items in calculation.
- add the refunded amount, be it partial or complete, to the order note.
- add the captured amount, be it partial or complete, to the order note.

Task: https://app.clickup.com/t/8694j8ve6