### PR TITLE
Respond with 500 in callback for missing orders

### DIFF
--- a/classes/class-dintero-checkout-callback.php
+++ b/classes/class-dintero-checkout-callback.php
@@ -40,6 +40,13 @@ class Dintero_Checkout_Callback {
 			die;
 		}
 
+		// Per request by Dintero, if the order doesn't exist, respond with 500.
+		$maybe_order = $this->get_order_from_reference( $merchant_reference );
+		if ( empty( $maybe_order ) ) {
+			http_response_code( 500 );
+			die;
+		}
+
 		$this->maybe_schedule_callback( $transaction_id, $merchant_reference, $error );
 
 		http_response_code( 200 );


### PR DESCRIPTION
When a callback hook is triggered, we schedule the action event for later consumption. As discussed with @andersem, we'll now check if the order exists, and otherwise respond with a 500 error before we schedule the action event.

Task: https://app.clickup.com/t/8694et4zc