### PR TITLE
Declare incompatibility with Checkout Blocks

### DIFF
--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -164,8 +164,10 @@ if ( ! class_exists( 'Dintero' ) ) {
 		 */
 		public function declare_wc_compatibility() {
 			// Declare HPOS compatibility.
+            // Declare Checkout Blocks incompatibility
 			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+                \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, false );
 			}
 		}
 


### PR DESCRIPTION
Declare incompatibility with Checkout Blocks so that merchants get a nice message when installing the plugin.
