### PR TITLE
Pass customer_type as array

### DIFF
--- a/classes/requests/post/class-dintero-checkout-create-session.php
+++ b/classes/requests/post/class-dintero-checkout-create-session.php
@@ -83,7 +83,7 @@ class Dintero_Checkout_Create_Session extends Dintero_Checkout_Request_Post {
 		$separate_shipping = wc_string_to_bool( $this->settings['express_allow_different_billing_shipping_address'] ?? 'no' );
 		if ( 'billing_only' !== $shipping_destination && $separate_shipping ) {
 			$customer_type = $this->settings['express_customer_type'];
-			$customer_type = 'b2bc' === $customer_type ? array( 'b2c', 'b2b' ) : $customer_type;
+			$customer_type = 'b2bc' === $customer_type ? array( 'b2c', 'b2b' ) : array( $customer_type );
 			$body['configuration']['allow_different_billing_shipping_address'] = $customer_type;
 
 			// By default this configuration is an empty array, therefore, we don't have to set it if $separate_shipping is set to false.


### PR DESCRIPTION
The `$customer_type` must be passed as an array, even if it is simple.

Task: https://app.clickup.com/t/8694wwtq5