### PR TITLE
Fix needed CSS file for express checkout not being loaded

### DIFF
--- a/classes/class-dintero-checkout-assets.php
+++ b/classes/class-dintero-checkout-assets.php
@@ -30,14 +30,16 @@ class Dintero_Checkout_Assets {
 	 * Loads style for the plugin.
 	 */
 	public function dintero_load_css() {
-		$settings = get_option( 'woocommerce_dintero_checkout_settings' );
-		if ( dwc_is_express( $settings ) ) {
-			return;
-		}
 		if ( ! is_checkout() ) {
 			return;
 		}
+
 		if ( is_order_received_page() ) {
+			return;
+		}
+
+		$settings = get_option( 'woocommerce_dintero_checkout_settings' );
+		if ( ! dwc_is_express( $settings ) ) {
 			return;
 		}
 


### PR DESCRIPTION
We should check if `! dwc_is_express`. That is, only return if it is _not_ express.

Reordered `if` statements to avoid reading from the database (`get_option`) unless we're sure this is a page we need the CSS file for.

Task: https://app.clickup.com/t/8694xghd0