### PR TITLE
Save billing address to shipping address fields when defaulting to shipping

### DIFF
--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -349,6 +349,16 @@ jQuery( function ( $ ) {
                     $( "#billing_phone" ).val( billingAddress.phone_number )
                 }
 
+                // 'billing' => Default to customer billing address
+                // 'shipping' => Default to customer shipping address
+                // 'billing_only' => Force shipping to the customer billing address only.
+                if (
+                    "shipping" === dinteroCheckoutParams.woocommerceShipToDestination &&
+                    ! dinteroCheckoutParams.allowDifferentBillingShippingAddress
+                ) {
+                    dinteroCheckoutForWooCommerce.saveAddressToShippingFields( billingAddress )
+                }
+
                 /**
                  * Dintero does not require first and last name for business purchases, whereas this is required by WooCommerce.
                  * For this purpose, we have to add 'N/A' to these fields. These default values will be overwritten the
@@ -372,53 +382,7 @@ jQuery( function ( $ ) {
                 shippingAddress &&
                 Object.keys( shippingAddress ).length > 1
             ) {
-                if ( shippingAddress.co_address ) {
-                    shippingAddress.first_name =
-                        shippingAddress.first_name ||
-                        shippingAddress.co_address.split( " " )[ 0 ] ||
-                        shippingAddress.business_name
-                    shippingAddress.last_name =
-                        shippingAddress.last_name ||
-                        shippingAddress.co_address.split( " " )[ 1 ] ||
-                        shippingAddress.business_name
-                }
-
-                $( "#ship-to-different-address-checkbox" ).prop( "checked", true )
-                $( "#ship-to-different-address-checkbox" ).change()
-                $( "#ship-to-different-address-checkbox" ).blur()
-
-                if ( "first_name" in shippingAddress ) {
-                    $( "#shipping_first_name" ).val( shippingAddress.first_name )
-                }
-
-                if ( "last_name" in shippingAddress ) {
-                    $( "#shipping_last_name" ).val( shippingAddress.last_name )
-                }
-
-                if ( "business_name" in shippingAddress ) {
-                    if ( 0 === $( "#billing_company" ).length ) {
-                        $( "#billing_company" ).val( shippingAddress.business_name )
-                    }
-
-                    $( "#shipping_company" ).val( shippingAddress.business_name )
-                }
-
-                if ( "address_line" in shippingAddress ) {
-                    $( "#shipping_address_1" ).val( shippingAddress.address_line )
-                }
-
-                if ( "postal_code" in shippingAddress ) {
-                    $( "#shipping_postcode" ).val( shippingAddress.postal_code )
-                }
-
-                if ( "postal_place" in shippingAddress ) {
-                    $( "#shipping_city" ).val( shippingAddress.postal_place )
-                }
-
-                if ( "country" in shippingAddress ) {
-                    $( "#shipping_country" ).val( shippingAddress.country )
-                    $( "#shipping_country" ).change()
-                }
+                dinteroCheckoutForWooCommerce.saveAddressToShippingFields( shippingAddress )
 
                 /**
                  * Dintero does not require first and last name for business purchases, whereas this is required by WooCommerce.
@@ -447,6 +411,51 @@ jQuery( function ( $ ) {
                 $( "#billing_email" ).change()
                 $( "#billing_email" ).blur()
                 $( "form.checkout" ).trigger( "update_checkout" )
+            }
+        },
+
+        /**
+         * Saves the address to the shipping fields.
+         *
+         * @param {Object} address - The address object containing address details.
+         */
+        saveAddressToShippingFields( address ) {
+            if ( address.co_address ) {
+                address.first_name = address.first_name || address.co_address.split( " " )[ 0 ] || address.business_name
+                address.last_name = address.last_name || address.co_address.split( " " )[ 1 ] || address.business_name
+            }
+
+            if ( "first_name" in address ) {
+                $( "#shipping_first_name" ).val( address.first_name )
+            }
+
+            if ( "last_name" in address ) {
+                $( "#shipping_last_name" ).val( address.last_name )
+            }
+
+            if ( "business_name" in address ) {
+                if ( 0 === $( "#billing_company" ).length ) {
+                    $( "#billing_company" ).val( address.business_name )
+                }
+
+                $( "#shipping_company" ).val( address.business_name )
+            }
+
+            if ( "address_line" in address ) {
+                $( "#shipping_address_1" ).val( address.address_line )
+            }
+
+            if ( "postal_code" in address ) {
+                $( "#shipping_postcode" ).val( address.postal_code )
+            }
+
+            if ( "postal_place" in address ) {
+                $( "#shipping_city" ).val( address.postal_place )
+            }
+
+            if ( "country" in address ) {
+                $( "#shipping_country" ).val( address.country )
+                $( "#shipping_country" ).change()
             }
         },
 

--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -420,6 +420,8 @@ jQuery( function ( $ ) {
          * @param {Object} address - The address object containing address details.
          */
         saveAddressToShippingFields( address ) {
+            $( "#ship-to-different-address-checkbox" ).prop( "checked", true )
+
             if ( address.co_address ) {
                 address.first_name = address.first_name || address.co_address.split( " " )[ 0 ] || address.business_name
                 address.last_name = address.last_name || address.co_address.split( " " )[ 1 ] || address.business_name

--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -353,7 +353,7 @@ jQuery( function ( $ ) {
                 // 'shipping' => Default to customer shipping address
                 // 'billing_only' => Force shipping to the customer billing address only.
                 if (
-                    "shipping" === dinteroCheckoutParams.woocommerceShipToDestination &&
+                    "billing_only" !== dinteroCheckoutParams.woocommerceShipToDestination &&
                     ! dinteroCheckoutParams.allowDifferentBillingShippingAddress
                 ) {
                     dinteroCheckoutForWooCommerce.saveAddressToShippingFields( billingAddress )

--- a/classes/class-dintero-checkout-assets.php
+++ b/classes/class-dintero-checkout-assets.php
@@ -187,6 +187,7 @@ class Dintero_Checkout_Assets {
 				'verifyOrderTotalNonce'                => wp_create_nonce( 'dintero_verify_order_total' ),
 				'verifyOrderTotalError'                => __( 'The cart was modified. Please try again.', 'dintero-checkout-for-woocommerce' ),
 				'allowDifferentBillingShippingAddress' => 'yes' === ( $settings['express_allow_different_billing_shipping_address'] ?? 'no' ) ? true : false,
+				'woocommerceShipToDestination'         => get_option( 'woocommerce_ship_to_destination' ),
 			)
 		);
 


### PR DESCRIPTION
If the default shipping destination is set to shipping, Woo will check the "ship to different address" checkbox, requiring the shipping address. However, a separate shipping address is only set if the merchant has enabled "Allow separate shipping address" in the Dintero plugin settings.

In the case of when this plugin setting is not enabled, we'll save the billing address to the shipping address fields.

Task: https://app.clickup.com/t/8694ya2v5