### PR TITLE
Version 1.10.5

### DIFF
--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -349,6 +349,16 @@ jQuery( function ( $ ) {
                     $( "#billing_phone" ).val( billingAddress.phone_number )
                 }
 
+                // 'billing' => Default to customer billing address
+                // 'shipping' => Default to customer shipping address
+                // 'billing_only' => Force shipping to the customer billing address only.
+                if (
+                    "billing_only" !== dinteroCheckoutParams.woocommerceShipToDestination &&
+                    ! dinteroCheckoutParams.allowDifferentBillingShippingAddress
+                ) {
+                    dinteroCheckoutForWooCommerce.saveAddressToShippingFields( billingAddress )
+                }
+
                 /**
                  * Dintero does not require first and last name for business purchases, whereas this is required by WooCommerce.
                  * For this purpose, we have to add 'N/A' to these fields. These default values will be overwritten the
@@ -372,53 +382,7 @@ jQuery( function ( $ ) {
                 shippingAddress &&
                 Object.keys( shippingAddress ).length > 1
             ) {
-                if ( shippingAddress.co_address ) {
-                    shippingAddress.first_name =
-                        shippingAddress.first_name ||
-                        shippingAddress.co_address.split( " " )[ 0 ] ||
-                        shippingAddress.business_name
-                    shippingAddress.last_name =
-                        shippingAddress.last_name ||
-                        shippingAddress.co_address.split( " " )[ 1 ] ||
-                        shippingAddress.business_name
-                }
-
-                $( "#ship-to-different-address-checkbox" ).prop( "checked", true )
-                $( "#ship-to-different-address-checkbox" ).change()
-                $( "#ship-to-different-address-checkbox" ).blur()
-
-                if ( "first_name" in shippingAddress ) {
-                    $( "#shipping_first_name" ).val( shippingAddress.first_name )
-                }
-
-                if ( "last_name" in shippingAddress ) {
-                    $( "#shipping_last_name" ).val( shippingAddress.last_name )
-                }
-
-                if ( "business_name" in shippingAddress ) {
-                    if ( 0 === $( "#billing_company" ).length ) {
-                        $( "#billing_company" ).val( shippingAddress.business_name )
-                    }
-
-                    $( "#shipping_company" ).val( shippingAddress.business_name )
-                }
-
-                if ( "address_line" in shippingAddress ) {
-                    $( "#shipping_address_1" ).val( shippingAddress.address_line )
-                }
-
-                if ( "postal_code" in shippingAddress ) {
-                    $( "#shipping_postcode" ).val( shippingAddress.postal_code )
-                }
-
-                if ( "postal_place" in shippingAddress ) {
-                    $( "#shipping_city" ).val( shippingAddress.postal_place )
-                }
-
-                if ( "country" in shippingAddress ) {
-                    $( "#shipping_country" ).val( shippingAddress.country )
-                    $( "#shipping_country" ).change()
-                }
+                dinteroCheckoutForWooCommerce.saveAddressToShippingFields( shippingAddress )
 
                 /**
                  * Dintero does not require first and last name for business purchases, whereas this is required by WooCommerce.
@@ -447,6 +411,53 @@ jQuery( function ( $ ) {
                 $( "#billing_email" ).change()
                 $( "#billing_email" ).blur()
                 $( "form.checkout" ).trigger( "update_checkout" )
+            }
+        },
+
+        /**
+         * Saves the address to the shipping fields.
+         *
+         * @param {Object} address - The address object containing address details.
+         */
+        saveAddressToShippingFields( address ) {
+            $( "#ship-to-different-address-checkbox" ).prop( "checked", true )
+
+            if ( address.co_address ) {
+                address.first_name = address.first_name || address.co_address.split( " " )[ 0 ] || address.business_name
+                address.last_name = address.last_name || address.co_address.split( " " )[ 1 ] || address.business_name
+            }
+
+            if ( "first_name" in address ) {
+                $( "#shipping_first_name" ).val( address.first_name )
+            }
+
+            if ( "last_name" in address ) {
+                $( "#shipping_last_name" ).val( address.last_name )
+            }
+
+            if ( "business_name" in address ) {
+                if ( 0 === $( "#billing_company" ).length ) {
+                    $( "#billing_company" ).val( address.business_name )
+                }
+
+                $( "#shipping_company" ).val( address.business_name )
+            }
+
+            if ( "address_line" in address ) {
+                $( "#shipping_address_1" ).val( address.address_line )
+            }
+
+            if ( "postal_code" in address ) {
+                $( "#shipping_postcode" ).val( address.postal_code )
+            }
+
+            if ( "postal_place" in address ) {
+                $( "#shipping_city" ).val( address.postal_place )
+            }
+
+            if ( "country" in address ) {
+                $( "#shipping_country" ).val( address.country )
+                $( "#shipping_country" ).change()
             }
         },
 

--- a/classes/class-dintero-checkout-assets.php
+++ b/classes/class-dintero-checkout-assets.php
@@ -187,6 +187,7 @@ class Dintero_Checkout_Assets {
 				'verifyOrderTotalNonce'                => wp_create_nonce( 'dintero_verify_order_total' ),
 				'verifyOrderTotalError'                => __( 'The cart was modified. Please try again.', 'dintero-checkout-for-woocommerce' ),
 				'allowDifferentBillingShippingAddress' => 'yes' === ( $settings['express_allow_different_billing_shipping_address'] ?? 'no' ) ? true : false,
+				'woocommerceShipToDestination'         => get_option( 'woocommerce_ship_to_destination' ),
 			)
 		);
 

--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Dintero offers a complete payment solution. Simplifying the payment process for you and the customer.
  * Author: Dintero, Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.10.4
+ * Version: 1.10.5
  * Text Domain: dintero-checkout-for-woocommerce
  * Domain Path: /languages
  *
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'DINTERO_CHECKOUT_VERSION', '1.10.4' );
+define( 'DINTERO_CHECKOUT_VERSION', '1.10.5' );
 define( 'DINTERO_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_MAIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -83,8 +83,8 @@ Go to [https://www.dintero.com/contact-us](https://www.dintero.com/contact-us) t
 
 == Changelog ==
 = 2024.07.01    - version 1.10.5 =
-* Fix           - Fixed an issue where the if the "Shipping destination" in Woo was set to default to shipping, the checkout validation would always be rejected due to missing shipping address.
-* Fix           - Fixed an issue where the shipping address fields were not always enabled although the plugin setting "Allow separate shipping address" was enabled.
+* Fix           - Fixed an issue where if the "Shipping destination" in Woo was set to default to shipping, the checkout validation would always be rejected due to missing shipping address.
+* Fix           - Fixed an issue where the shipping address fields were not always enabled, although the plugin setting "Allow separate shipping address" was enabled.
 
 = 2024.06.26    - version 1.10.4 =
 * Fix           - Fixed an issue where the CSS file was not enqueued causing the checkout layout for Express checkout to always be a single-column.

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,10 @@ Go to [https://www.dintero.com/contact-us](https://www.dintero.com/contact-us) t
 1. The plugin settings screen where you set up the details to connect to Dintero.
 
 == Changelog ==
+= 2024.07.01    - version 1.10.5 =
+* Fix           - Fixed an issue where the if the "Shipping destination" in Woo was set to default to shipping, the checkout validation would always be rejected due to missing shipping address.
+* Fix           - Fixed an issue where the shipping address fields were not always enabled although the plugin setting "Allow separate shipping address" was enabled.
+
 = 2024.06.26    - version 1.10.4 =
 * Fix           - Fixed an issue where the CSS file was not enqueued causing the checkout layout for Express checkout to always be a single-column.
 


### PR DESCRIPTION
* Fix           - Fixed an issue where if the "Shipping destination" in Woo was set to default to shipping, the checkout validation would always be rejected due to missing shipping address.
* Fix           - Fixed an issue where the shipping address fields were not always enabled, although the plugin setting "Allow separate shipping address" was enabled.

Note, this release is for advanced users and developers only.