### PR TITLE
Settings migration not migrating old settings properly

### DIFF
--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -63,7 +63,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 					$flow = 'express_' . ( 'yes' === $popout ? 'popout' : 'embedded' );
 				} else {
 					// We don't need to check for pop-out since it's only available for express checkout.
-					$flow = 'checkout_' . ( 'yes' === $form_factor ? 'redirect' : 'embedded' );
+					$flow = 'checkout_' . $form_factor;
 				}
 
 				$this->update_option( $this->plugin_id . $this->id . '_checkout_flow', $flow );

--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -55,12 +55,13 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 
 			// Migrate existing settings to use the new "checkout_flow" setting.
 			if ( ! isset( $this->settings['checkout_flow'] ) ) {
-				$checkout_type = $this->settings['checkout_type'] ?? 'express';
-				$form_factor   = $this->settings['form_factor'] ?? 'redirect';
-				$popout        = $this->settings['checkout_popout'] ?? 'no';
+				$checkout_type = $this->settings['checkout_type'] ?? 'express'; // embedded|express.
+				$form_factor   = $this->settings['form_factor'] ?? 'redirect'; // express|redirect.
+				$popout        = $this->settings['checkout_popout'] ?? 'no'; // yes|no.
 
 				if ( 'embedded' === $form_factor ) {
-					$flow = ( 'express' === $checkout_type ? 'express' : 'checkout' ) . '_' . ( 'yes' === $popout ? 'popout' : 'embedded' );
+					$display = 'yes' === $popout ? 'popout' : 'embedded';
+					$flow    = "{$checkout_type}_{$display}";
 				} else {
 					$flow = 'checkout_redirect';
 				}

--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -65,7 +65,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 					$flow = 'checkout_' . $form_factor;
 				}
 
-				$this->update_option( $this->plugin_id . $this->id . '_checkout_flow', $flow );
+				$this->update_option( 'checkout_flow', $flow );
 				$this->settings['checkout_flow'] = $flow;
 			}
 

--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -62,8 +62,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				if ( 'express' === $checkout_type ) {
 					$flow = 'express_' . ( 'yes' === $popout ? 'popout' : 'embedded' );
 				} else {
-					// We don't need to check for pop-out since it's only available for express checkout.
-					$flow = 'checkout_' . $form_factor;
+					$flow = 'checkout_' . ( 'yes' === $popout ? 'popout' : $form_factor );
 				}
 
 				$this->update_option( $this->plugin_id . $this->id . '_checkout_flow', $flow );

--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -62,7 +62,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				if ( 'embedded' === $form_factor ) {
 					$flow = ( 'express' === $checkout_type ? 'express' : 'checkout' ) . '_' . ( 'yes' === $popout ? 'popout' : 'embedded' );
 				} else {
-					$flow = 'checkout_' . $form_factor;
+					$flow = 'checkout_redirect';
 				}
 
 				$this->update_option( 'checkout_flow', $flow );

--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -59,10 +59,10 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				$form_factor   = $this->settings['form_factor'] ?? 'redirect';
 				$popout        = $this->settings['checkout_popout'] ?? 'no';
 
-				if ( 'express' === $checkout_type ) {
-					$flow = 'express_' . ( 'yes' === $popout ? 'popout' : 'embedded' );
+				if ( 'embedded' === $form_factor ) {
+					$flow = ( 'express' === $checkout_type ? 'express' : 'checkout' ) . '_' . ( 'yes' === $popout ? 'popout' : 'embedded' );
 				} else {
-					$flow = 'checkout_' . ( 'yes' === $popout ? 'popout' : $form_factor );
+					$flow = 'checkout_' . $form_factor;
 				}
 
 				$this->update_option( $this->plugin_id . $this->id . '_checkout_flow', $flow );


### PR DESCRIPTION
The form factor will take precedence over the checkout type. I've verified that the setting is migrated accordingly, and that this is also what appears on the checkout page:

1. Dintero Checkout Embedded → Checkout Embedded.
2. Dintero Checkout Embedded + Pop-out→ Checkout Pop-out. 
3. Dintero Checkout Express → Checkout Express Embedded.
4. Dintero Checkout Express + Pop-out → Checkout Express Pop-out. 
5. Dintero Checkout Express Redirect → Checkout Redirect. 
6. Dintero Checkout Redirect → Checkout Redirect.

https://app.clickup.com/t/86952e22r
