### PR TITLE
Do not call save() when processing order item

### DIFF
--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -99,8 +99,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 * @return void
 		 */
 		public function create_order_line_item( $item, $cart_item_key ) {
-			$item->update_meta_data( '_dintero_checkout_line_id', $cart_item_key );
-			$item->save();
+			$item->add_meta_data( '_dintero_checkout_line_id', $cart_item_key, true );
 		}
 
 		/**


### PR DESCRIPTION
Calling save() causes the order ID to return 0 (or sometimes `null`) in the `woocommerce_new_order_item` action hook if the priority is too low. This has caused a compatibility issue with plugins that rely on the order ID to be available.

Since the save() is not necessary when processing order items (it is however required for orders), we can safely remove it.

Furthermore, we don't need to call `update_meta_data` since the order line is only added once. Instead `add_meta_data` suffices.

Tested w/wo HPOS.

https://app.clickup.com/t/86955260q