### PR TITLE
Version 1.10.7

### DIFF
--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -99,8 +99,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 * @return void
 		 */
 		public function create_order_line_item( $item, $cart_item_key ) {
-			$item->update_meta_data( '_dintero_checkout_line_id', $cart_item_key );
-			$item->save();
+			$item->add_meta_data( '_dintero_checkout_line_id', $cart_item_key, true );
 		}
 
 		/**

--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Dintero offers a complete payment solution. Simplifying the payment process for you and the customer.
  * Author: Dintero, Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.10.6
+ * Version: 1.10.7
  * Text Domain: dintero-checkout-for-woocommerce
  * Domain Path: /languages
  *
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'DINTERO_CHECKOUT_VERSION', '1.10.6' );
+define( 'DINTERO_CHECKOUT_VERSION', '1.10.7' );
 define( 'DINTERO_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_MAIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.4.1
 Requires PHP: 7.0
 WC requires at least: 6.1.0
 WC tested up to: 8.2.1
-Stable tag: 1.10.6
+Stable tag: 1.10.7
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,9 @@ Go to [https://www.dintero.com/contact-us](https://www.dintero.com/contact-us) t
 1. The plugin settings screen where you set up the details to connect to Dintero.
 
 == Changelog ==
+= 2024.08.19    - version 1.10.7 =
+* Fix           - Fixed an issue related to 'woocommerce_new_order_item' where calling save() would result in the order ID being set to 0. This should improve compatibility with other third-party plugins that hook onto this action.
+
 = 2024.07.11    - version 1.10.6 =
 * Fix           - Fixed an issue related to the plugin settings overhaul. The setting migration should now work as intended. Please verify that the new "Checkout flow" plugin setting option is what you expect.
 


### PR DESCRIPTION
* Fix           - Fixed an issue related to 'woocommerce_new_order_item' where calling save() would result in the order ID being set to 0. This should improve compatibility with other third-party plugins that hook onto this action.