### PR TITLE
Version 1.10.8

### DIFF
--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -5,14 +5,14 @@
  * Description: Dintero offers a complete payment solution. Simplifying the payment process for you and the customer.
  * Author: Dintero, Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.10.7
+ * Version: 1.10.8
  * Text Domain: dintero-checkout-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 6.1.0
- * WC tested up to: 8.2.1
+ * WC tested up to: 9.5.1
  *
- * Copyright (c) 2024 Krokedil
+ * Copyright (c) 2025 Krokedil
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'DINTERO_CHECKOUT_VERSION', '1.10.7' );
+define( 'DINTERO_CHECKOUT_VERSION', '1.10.8' );
 define( 'DINTERO_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DINTERO_CHECKOUT_MAIN_FILE', __FILE__ );

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -157,6 +157,7 @@ function dintero_update_wc_shipping( $data ) {
  */
 function dintero_confirm_order( $order, $transaction_id ) {
 	$order_id = $order->get_id();
+
 	$settings = get_option( 'woocommerce_dintero_checkout_settings' );
 
 	// Save the environment mode for use in the meta box.
@@ -168,6 +169,9 @@ function dintero_confirm_order( $order, $transaction_id ) {
 	/* Remove duplicate words from the payment method type (e.g., swish.swish → Swish). Otherwise, prints as is (e.g., collector.invoice → Collector Invoice). */
 	$payment_method = dintero_get_payment_method_name( wc_get_var( $dintero_order['payment_product_type'], $order->get_meta( '_dintero_payment_method' ) ) );
 	$order->update_meta_data( '_dintero_payment_method', $payment_method );
+
+	// Get the order from the database again to prevent any concurrency issues if the page loads twice at the same time.
+	$order = wc_get_order( $order_id );
 
 	$require_authorization = ( ! is_wp_error( $dintero_order ) && 'ON_HOLD' === $dintero_order['status'] );
 	if ( $require_authorization ) {

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 5.8.3
 Tested up to: 6.7.1
 Requires PHP: 7.4
 WC requires at least: 6.1.0
-WC tested up to: 9.4.3
-Stable tag: 1.10.7
+WC tested up to: 9.5.1
+Stable tag: 1.10.8
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,9 @@ Go to [https://www.dintero.com/contact-us](https://www.dintero.com/contact-us) t
 1. The plugin settings screen where you set up the details to connect to Dintero.
 
 == Changelog ==
+= 2025.01.07    - version 1.10.8 =
+* Enhancement   - We will now read the order again from the database before checking if it's already been confirmed before processing the confirmation step, this is to ensure that the order is not confirmed twice, which could happen in rare cases and caused stock values to be reduced twice in WooCommerce.
+
 = 2024.08.19    - version 1.10.7 =
 * Fix           - Fixed an issue related to 'woocommerce_new_order_item' where calling save() would result in the order ID being set to 0. This should improve compatibility with other third-party plugins that hook onto this action.
 
@@ -155,7 +158,7 @@ Go to [https://www.dintero.com/contact-us](https://www.dintero.com/contact-us) t
 
 = 2023.03.09    - version 1.5.1 =
 * Fix           - Email notification should now be sent as expected when changing order status from "Manual review" provided that email notifications is enabled in the WooCommerce settings.
-* Fix           - Fixed an issue where placing an order failed when the shipping address fields were unset, and Embedded Dintero Checkout was used. 
+* Fix           - Fixed an issue where placing an order failed when the shipping address fields were unset, and Embedded Dintero Checkout was used.
 * Tweak         - A blank character is used as a placeholder when shipping first and last name is not available. Previously, this was "N/A".
 
 = 2023.02.01    - version 1.5.0 =
@@ -208,7 +211,7 @@ Go to [https://www.dintero.com/contact-us](https://www.dintero.com/contact-us) t
 = 2022.08.18    - version 1.1.2 =
 * Tweak         - Better error handling especially in situations where there is no front end to display the error message (e.g., in a cronjob environment).
 * Fix           - Fixed various PHP notices.
-* Fix           - Fixed backward compatibility problem for orders that were placed prior to version 1.1.0. 
+* Fix           - Fixed backward compatibility problem for orders that were placed prior to version 1.1.0.
 
 = 2022.08.16    - version 1.1.1 =
 * Fix           - The metadata 'dintero_checkout_line_id' should now be hidden.


### PR DESCRIPTION
* Enhancement - We will now read the order again from the database before checking if it's already been confirmed before processing the confirmation step, this is to ensure that the order is not confirmed twice, which could happen in rare cases and caused stock values to be reduced twice in WooCommerce.