### PR TITLE
Match line_id for pickup points

### DIFF
--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -198,6 +198,12 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		public function process_payment( $order_id ) {
 			$order = wc_get_order( $order_id );
 
+			$shipping_line_id = WC()->session->get( 'dintero_shipping_line_id' );
+			if ( ! empty( $shipping_line_id ) ) {
+				$order->update_meta_data( '_dintero_shipping_line_id', $shipping_line_id );
+				$order->save();
+			}
+
 			if ( Dintero_Checkout_Subscription::is_change_payment_method() ) {
 				return $this->process_redirect_payment( $order );
 			}

--- a/classes/requests/helpers/class-dintero-checkout-helper-base.php
+++ b/classes/requests/helpers/class-dintero-checkout-helper-base.php
@@ -51,6 +51,7 @@ abstract class Dintero_Checkout_Helper_Base {
 		$shipping_option = $helper->get_shipping_option();
 		if ( ! empty( $shipping_option ) ) {
 			$body['order']['shipping_option'] = $shipping_option;
+			WC()->session->set( 'dintero_shipping_line_id', $shipping_option['line_id'] );
 		}
 
 		// If its express we need to add the express options.

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -431,7 +431,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			 * @var WC_Order_Item_Shipping $shipping_line The shipping line.
 			 */
 			$shipping_line    = array_values( $shipping_lines )[0];
-			$shipping_line_id = $this->order->get_meta( '_dintero_shipping_line_id' ) ?? $shipping_line->get_method_id() . ':' . $shipping_line->get_instance_id();
+			$shipping_line_id = ! empty( $this->order->get_meta( '_dintero_shipping_line_id' ) ) ? $this->order->get_meta( '_dintero_shipping_line_id' ) : $shipping_line->get_method_id() . ':' . $shipping_line->get_instance_id();
 
 			// Retrieve the shipping id from the order object itself.
 			$shipping_id = $this->order->get_meta( '_wc_dintero_shipping_id' );

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -430,7 +430,8 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			 *
 			 * @var WC_Order_Item_Shipping $shipping_line The shipping line.
 			 */
-			$shipping_line = array_values( $shipping_lines )[0];
+			$shipping_line    = array_values( $shipping_lines )[0];
+			$shipping_line_id = $this->order->get_meta( '_dintero_shipping_line_id' ) ?? $shipping_line->get_method_id() . ':' . $shipping_line->get_instance_id();
 
 			// Retrieve the shipping id from the order object itself.
 			$shipping_id = $this->order->get_meta( '_wc_dintero_shipping_id' );
@@ -449,7 +450,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 
 			return array(
 				'id'          => $shipping_id,
-				'line_id'     => $shipping_id,
+				'line_id'     => $shipping_line_id,
 				'amount'      => absint( self::format_number( $shipping_line->get_total() + $shipping_line->get_total_tax() ) ),
 				'operator'    => '',
 				'description' => '',


### PR DESCRIPTION
Store and use the correct line_id when using pickup points, to avoid mismatch for Walley payments on order capture.