### PR TITLE
decode shipping method title

### DIFF
--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -366,7 +366,7 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 			'amount'          => self::format_number( $shipping_rate->get_cost() + $shipping_rate->get_shipping_tax() ),
 			'operator'        => '',
 			'description'     => '',
-			'title'           => $shipping_rate->get_label(),
+			'title'           => html_entity_decode( $shipping_rate->get_label() ),
 			'delivery_method' => 'unspecified',
 			'vat_amount'      => self::format_number( $shipping_rate->get_shipping_tax() ),
 			'vat'             => ( empty( floatval( $shipping_rate->get_cost() ) ) ) ? 0 : self::format_number( $shipping_rate->get_shipping_tax() / $shipping_rate->get_cost() ),


### PR DESCRIPTION
Decode shipping method title in request body on create session, to avoid showing encoded shipping title in iframe.

Not sure if this is the best solution for this, but it does solve the issue at hand.