### PR TITLE
Check checkout flow before updating address

### DIFF
--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -304,6 +304,10 @@ jQuery( function ( $ ) {
 
         /* Maybe update the shipping and billing address. */
         updateAddress( billingAddress, shippingAddress, finalize = false ) {
+            if( 'checkout_embedded' === dinteroCheckoutParams.checkout_flow ) {
+                return;
+            }
+
             let update = false
 
             if ( billingAddress ) {

--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -304,7 +304,7 @@ jQuery( function ( $ ) {
 
         /* Maybe update the shipping and billing address. */
         updateAddress( billingAddress, shippingAddress, finalize = false ) {
-            if( 'checkout_embedded' === dinteroCheckoutParams.checkout_flow ) {
+            if( 'express_popout' !== dinteroCheckoutParams.checkout_flow && 'express_embedded' !== dinteroCheckoutParams.checkout_flow ) {
                 return;
             }
 

--- a/classes/class-dintero-checkout-assets.php
+++ b/classes/class-dintero-checkout-assets.php
@@ -208,6 +208,7 @@ class Dintero_Checkout_Assets {
 				'verifyOrderTotalError'                => __( 'The cart was modified. Please try again.', 'dintero-checkout-for-woocommerce' ),
 				'allowDifferentBillingShippingAddress' => 'yes' === ( $settings['express_allow_different_billing_shipping_address'] ?? 'no' ) ? true : false,
 				'woocommerceShipToDestination'         => get_option( 'woocommerce_ship_to_destination' ),
+				'checkout_flow'                        => $settings['checkout_flow'] ?? 'express_popout',
 			)
 		);
 


### PR DESCRIPTION
Check which checkout flow is used before modifying address, to avoid issues with updating checkout billing/shipping fields where unnecessary for some checkout flows.