### PR TITLE
Addresses unsupported operand types: string + <numeric type> errors introduce in WC 9.9.x

### DIFF
--- a/classes/class-dintero-checkout-widget.php
+++ b/classes/class-dintero-checkout-widget.php
@@ -44,7 +44,7 @@ class Dintero_Checkout_Widget extends WP_Widget {
 			),
 		);
 		echo wp_kses( $args['before_widget'], $allowed_html );
-		if ( 'on' === $instance['use_default'] ) {
+		if ( 'on' === ( $instance['use_default'] ?? 'on' ) ) {
 			$this->print_icon();
 		} else {
 			$this->print_icon( $instance['icon_color'], $instance['background_color'] );

--- a/classes/class-dintero-checkout-widget.php
+++ b/classes/class-dintero-checkout-widget.php
@@ -123,5 +123,3 @@ class Dintero_Checkout_Widget extends WP_Widget {
 		<?php
 	}
 }
-
-new Dintero_Checkout_Widget();

--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -398,11 +398,14 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 		$meta    = $rate->get_meta_data();
 		$carrier = isset( $meta['carrier'] ) ? strtolower( $meta['carrier'] ) : $meta['udc_carrier_id'];
 
+		// As of WC 9.9.x, the cost has to be converted to a float otherwise you may risk receive a simple double-quote (") if the shipping cost is not set.
+		$shipping_cost = floatval( $rate->get_cost() );
+
 		$line_id = "{$rate->get_id()}:{$pickup_point->get_id()}";
 		return array(
 			'id'                  => $rate->get_id(),
 			'line_id'             => $line_id,
-			'amount'              => self::format_number( floatval( $rate->get_cost() ) + $rate->get_shipping_tax() ),
+			'amount'              => self::format_number( $shipping_cost + $rate->get_shipping_tax() ),
 			'operator'            => $this->get_operator( $carrier ),
 			'operator_product_id' => $pickup_point->get_id(),
 			'title'               => $rate->get_label(),

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -302,9 +302,12 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 	 * @return array
 	 */
 	public function get_fee( $order_item ) {
+		$fee_total     = floatval( $order_item->get_total() );
+		$fee_total_tax = floatval( $order_item->get_total_tax() );
+
 		$name       = $order_item->get_name();
-		$amount     = absint( self::format_number( floatval( $order_item->get_total() ) + floatval( $order_item->get_total_tax() ) ) );
-		$vat_amount = absint( self::format_number( floatval( $order_item->get_total_tax() ) ) );
+		$amount     = absint( self::format_number( $fee_total + $fee_total_tax ) );
+		$vat_amount = absint( self::format_number( $fee_total_tax ) );
 
 		return array(
 			/* NOTE: The id and line_id must match the same id and line_id on capture and refund. */
@@ -314,7 +317,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			'quantity'    => 1,
 			'amount'      => $amount,
 			'vat_amount'  => $vat_amount,
-			'vat'         => empty( $amount ) ? 0 : $vat_amount / $amount,
+			'vat'         => $amount <= 0 ? 0 : $vat_amount / $amount,
 		);
 	}
 
@@ -464,7 +467,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 				'description' => '',
 				'title'       => $shipping_line->get_method_title(),
 				'vat_amount'  => self::format_number( $shipping_total_tax ),
-				'vat'         => $shipping_total <= 0 ? 0 : self::format_number( $shipping_line->get_total_tax() / $shipping_line->get_total() ),
+				'vat'         => $shipping_total <= 0 ? 0 : self::format_number( $shipping_total_tax / $shipping_total ),
 			);
 		}
 		return null;

--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -103,9 +103,17 @@ if ( ! class_exists( 'Dintero' ) ) {
 		 * Class constructor.
 		 */
 		public function __construct() {
-			add_action( 'init', array( $this, 'load_textdomain' ) );
 			add_action( 'plugin_loaded', array( $this, 'init' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
+
+			// Postpone loading of textdomain until the plugin is loaded.
+			add_action( 'init', array( $this, 'load_textdomain' ), 0 );
+			// Since the Widget class references the textdomain, we need to load it after the textdomain is registered.
+			add_action( 'widgets_init', array( $this, 'register_widget' ) );
+		}
+
+		public function register_widget() {
+			register_widget( 'Dintero_Checkout_Widget' );
 		}
 
 		/**
@@ -215,18 +223,18 @@ if ( ! class_exists( 'Dintero' ) ) {
 
 			add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateways' ) );
 
-			add_action(
-				'widgets_init',
-				function () {
-					register_widget( 'Dintero_Checkout_Widget' );
-				}
-			);
-
 			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
-
 			add_action( 'admin_notices', array( $this, 'dintero_wc_zero_decimal_notice' ) );
 		}
 
+		/**
+		 * Load the plugin text domain for translation.
+		 *
+		 * @return void
+		 */
+		public function load_textdomain() {
+			load_plugin_textdomain( 'dintero-checkout-for-woocommerce', false, plugin_basename( __DIR__ ) . '/languages' );
+		}
 
 		/**
 		 * Display a notice if the WooCommerce decimal setting is set to 0.
@@ -254,15 +262,6 @@ if ( ! class_exists( 'Dintero' ) ) {
 				</div>
 				<?php
 			}
-		}
-
-		/**
-		 * Load the plugin text domain for translation.
-		 *
-		 * @return void
-		 */
-		public function load_textdomain() {
-			load_plugin_textdomain( 'dintero-checkout-for-woocommerce', false, plugin_basename( __DIR__ ) . '/languages' );
 		}
 
 		/**

--- a/dintero-checkout-for-woocommerce.php
+++ b/dintero-checkout-for-woocommerce.php
@@ -103,6 +103,7 @@ if ( ! class_exists( 'Dintero' ) ) {
 		 * Class constructor.
 		 */
 		public function __construct() {
+			add_action( 'init', array( $this, 'load_textdomain' ) );
 			add_action( 'plugin_loaded', array( $this, 'init' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
 		}
@@ -213,7 +214,6 @@ if ( ! class_exists( 'Dintero' ) ) {
 			$this->order_management = Dintero_Checkout_Order_Management::get_instance();
 
 			add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateways' ) );
-			load_plugin_textdomain( 'dintero-checkout-for-woocommerce', false, plugin_basename( __DIR__ ) . '/languages' );
 
 			add_action(
 				'widgets_init',
@@ -254,6 +254,15 @@ if ( ! class_exists( 'Dintero' ) ) {
 				</div>
 				<?php
 			}
+		}
+
+		/**
+		 * Load the plugin text domain for translation.
+		 *
+		 * @return void
+		 */
+		public function load_textdomain() {
+			load_plugin_textdomain( 'dintero-checkout-for-woocommerce', false, plugin_basename( __DIR__ ) . '/languages' );
 		}
 
 		/**


### PR DESCRIPTION
In the 9.9.x release, WC changed how they handle the price for local shipping (pickup) when the default placeholder value is used instead. When a value is not set, `"` is returned, which causes an "unsupported operand types" since we attempt to perform calculation on a non-numeric string.

- converts any costs that may return a string to float before performing calculation.
- delay loading textdomain until `init`.
- delay loading the widget until textdomain is loaded.
- fixes undefined `use_default` index in widget.

https://app.clickup.com/t/8699c8th1
https://app.clickup.com/t/8699ctnx7