### PR TITLE
Update checkout on mount

### DIFF
--- a/assets/js/dintero-checkout-express.js
+++ b/assets/js/dintero-checkout-express.js
@@ -4,8 +4,6 @@ jQuery( function ( $ ) {
         return
     }
 
-    const gatewayParams = dinteroCheckoutParams
-
     const dinteroCheckoutForWooCommerce = {
         bodyEl: $( "body" ),
         checkoutFormSelector: "form.checkout",


### PR DESCRIPTION
Since it takes time for the Dintero iframe to be mounted, and the `update_checkout` during `document.ready` happens too quickly, the update request fails. 

- use the `.then` clause to unlock the update request, and trigger the update event.

https://app.clickup.com/t/8699fgqwz