### PR TITLE
Add the operator even if empty

### DIFF
--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -259,8 +259,11 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 			// Check if the WC session has any chosen shipping methods instead.
 			if ( empty( $chosen_shipping ) ) {
 				$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
-				$chosen_shipping_id      = reset( $chosen_shipping_methods );
+				if ( empty( $chosen_shipping_methods ) ) {
+					return $chosen_shipping;
+				}
 
+				$chosen_shipping_id         = reset( $chosen_shipping_methods );
 				$available_shipping_options = $this->get_shipping_items();
 				foreach ( $available_shipping_options as $shipping_option ) {
 					if ( $shipping_option['id'] === $chosen_shipping_id ) {

--- a/classes/requests/helpers/class-dintero-checkout-helper-base.php
+++ b/classes/requests/helpers/class-dintero-checkout-helper-base.php
@@ -80,8 +80,8 @@ abstract class Dintero_Checkout_Helper_Base {
 	/**
 	 * Retrieve the icon URL for a given carrier.
 	 *
-	 * @param string                                  $carrier
-	 * @param WC_Shipping_Rate|WC_Order_Item_Shipping $shipping_rate
+	 * @param string                                  $carrier The carrier name.
+	 * @param WC_Shipping_Rate|WC_Order_Item_Shipping $shipping_rate The shipping rate or order item shipping passed to the filter `dwc_shipping_icon`.
 	 * @return string URL.
 	 */
 	protected function get_pickup_point_icon( $carrier, $shipping_rate ) {

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -403,6 +403,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			'delivery_method' => 'unspecified',
 			'vat_amount'      => $shipping_cost <= 0 ? 0 : self::format_number( $shipping_tax ),
 			'vat'             => $shipping_cost <= 0 ? 0 : self::format_number( $shipping_tax / $shipping_cost ),
+			'operator'        => '',
 			/* Since the shipping will be added to the list of products, it needs a quantity. */
 			'quantity'        => 1,
 			/* Dintero needs to know this is an order with multiple shipping options by setting the 'type'. */


### PR DESCRIPTION
Redirect is failing due to missing `operator` property. This also addresses an issue when a cart containing only virtual products crashes due to nonexisting shipping.

https://app.clickup.com/t/8699n3hh1