### PR TITLE
Add 'logomark' as a logo style setting

### DIFF
--- a/assets/css/dintero-checkout-general.css
+++ b/assets/css/dintero-checkout-general.css
@@ -3,7 +3,7 @@
     float: left;
 }
 
-ul.payment_methods label[for="payment_method_dintero_checkout"]:after {
+#payment ul.payment_methods label[for="payment_method_dintero_checkout"]:after {
     content: '';
     display: block;
     clear: left;

--- a/assets/css/dintero-checkout-general.css
+++ b/assets/css/dintero-checkout-general.css
@@ -1,9 +1,10 @@
-ul.payment_methods li img.dintero-logos {
+#payment ul.payment_methods li img.dintero-logos {
     min-height: 58px;
+    float: left;
 }
 
 ul.payment_methods label[for="payment_method_dintero_checkout"]:after {
     content: '';
     display: block;
-    clear: right;
+    clear: left;
 }

--- a/assets/css/dintero-checkout-general.css
+++ b/assets/css/dintero-checkout-general.css
@@ -1,10 +1,14 @@
-#payment ul.payment_methods li img.dintero-logos {
+ul.payment_methods li img.dintero-logos {
     min-height: 58px;
-    float: left;
 }
 
-#payment ul.payment_methods label[for="payment_method_dintero_checkout"]:after {
+ul.payment_methods label[for="payment_method_dintero_checkout"]:after {
     content: '';
     display: block;
-    clear: left;
+    clear: right;
 }
+
+#payment ul.payment_methods li img.dintero-logos.logo-variant-logomark {
+    float: none;
+}
+

--- a/classes/class-dintero-checkout-gateway.php
+++ b/classes/class-dintero-checkout-gateway.php
@@ -171,7 +171,10 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 * @return string
 		 */
 		public function get_icon() {
-			return '<img class="dintero-logos" src="' . esc_attr( dintero_get_brand_image_url() ) . '" style="max-width: 90%" alt="Dintero logo" />';
+			$settings = get_option( 'woocommerce_dintero_checkout_settings', array() );
+			$variant  = $settings['branding_logo_color_mode'] ?? 'logomark';
+
+			return '<img class="dintero-logos logo-variant-' . esc_attr( $variant ) . '" src="' . esc_attr( dintero_get_brand_image_url( $settings ) ) . '" style="max-width: 90%" alt="Dintero logo" />';
 		}
 
 		/**

--- a/classes/class-dintero-checkout-settings-fields.php
+++ b/classes/class-dintero-checkout-settings-fields.php
@@ -262,7 +262,7 @@ class Dintero_Settings_Fields {
 			'branding_logo_color_mode'                => array(
 				'title'   => __( 'Logo variant', 'dintero-checkout-for-woocommerce' ),
 				'type'    => 'select',
-				'label'   => __( 'Color mode', 'dintero-checkout-for-woocommerce' ),
+				'label'   => __( 'Logo variant', 'dintero-checkout-for-woocommerce' ),
 				'default' => 'logomark',
 				'options' => array(
 					'logomark'   => __( 'Logomark', 'dintero-checkout-for-woocommerce' ),

--- a/classes/class-dintero-checkout-settings-fields.php
+++ b/classes/class-dintero-checkout-settings-fields.php
@@ -260,13 +260,14 @@ class Dintero_Settings_Fields {
 				'type'  => 'color',
 			),
 			'branding_logo_color_mode'                => array(
-				'title'   => __( 'Logo color mode', 'dintero-checkout-for-woocommerce' ),
+				'title'   => __( 'Logo variant', 'dintero-checkout-for-woocommerce' ),
 				'type'    => 'select',
 				'label'   => __( 'Color mode', 'dintero-checkout-for-woocommerce' ),
-				'default' => 'color',
+				'default' => 'logomark',
 				'options' => array(
-					'colors'     => __( 'Light', 'dintero-checkout-for-woocommerce' ),
-					'darkcolors' => __( 'Dark', 'dintero-checkout-for-woocommerce' ),
+					'logomark'   => __( 'Logomark', 'dintero-checkout-for-woocommerce' ),
+					'colors'     => __( 'Light mode', 'dintero-checkout-for-woocommerce' ),
+					'darkcolors' => __( 'Dark mode', 'dintero-checkout-for-woocommerce' ),
 				),
 			),
 		);

--- a/classes/class-dintero-checkout-widget.php
+++ b/classes/class-dintero-checkout-widget.php
@@ -112,12 +112,14 @@ class Dintero_Checkout_Widget extends WP_Widget {
 	 * @return void
 	 */
 	private function print_icon( $icon_color = 'cecece', $background_color = false ) {
-		$icon_url = dintero_get_brand_image_url( $icon_color );
+		$settings = get_option( 'woocommerce_dintero_checkout_settings', array() );
+		$variant  = $settings['branding_logo_color_mode'] ?? 'logomark';
+		$icon_url = dintero_get_brand_image_url( $settings, $icon_color );
 
 		?>
 			<div style="padding: 20px 0; <?php echo ( ! empty( $background_color ) ) ? esc_attr( "background-color: $background_color" ) : ''; ?> ">
 			<a href="https://www.dintero.com" target="_blank" title="<?php echo dintero_keyword_backlinks(); ?>">
-				<img loading="lazy" style="margin: 0 auto;" src="<?php echo esc_attr( $icon_url ); ?>" style="max-width: 90%" alt="<?php echo dintero_alt_backlinks(); ?>" />
+				<img loading="lazy" class="logo-variant-<?php echo esc_attr( $variant ); ?>" style="margin: 0 auto;" src="<?php echo esc_attr( $icon_url ); ?>" style="max-width: 90%" alt="<?php echo dintero_alt_backlinks(); ?>" />
 			</a>
 			</div>
 		<?php

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -305,12 +305,12 @@ function dintero_confirm_order( $order, $transaction_id ) {
  * @return string URL
  */
 function dintero_get_brand_image_url( $icon_color = 'cecece' ) {
-	$settings = get_option( 'woocommerce_dintero_checkout_settings' );
+	$settings = get_option( 'woocommerce_dintero_checkout_settings', array() );
 
-	$variant  = $settings['branding_logo_color_mode'] ?? 'colors';
+	$variant  = $settings['branding_logo_color_mode'] ?? 'logomark';
 	$color    = str_replace( '#', '', $icon_color );
-	$width    = 600;
-	$template = 'dintero_top_frame';
+	$width    = 'logomark' === $variant ? 300 : 600;
+	$template = 'logomark' === $variant ? 'logos' : 'dintero_top_frame';
 	$account  = ( ( 'yes' === $settings['test_mode'] ) ? 'T' : 'P' ) . $settings['account_id'];
 	$profile  = $settings['profile_id'];
 

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -301,12 +301,11 @@ function dintero_confirm_order( $order, $transaction_id ) {
 /**
  * The URL to the branding image.
  *
- * @param  string $icon_color A hexadecimal RGB value for the foreground color. Default is #cecece.
+ * @param array  $settings The Dintero checkout settings.
+ * @param string $icon_color A hexadecimal RGB value for the foreground color. Default is #cecece.
  * @return string URL
  */
-function dintero_get_brand_image_url( $icon_color = 'cecece' ) {
-	$settings = get_option( 'woocommerce_dintero_checkout_settings', array() );
-
+function dintero_get_brand_image_url( $settings, $icon_color = 'cecece' ) {
 	$variant  = $settings['branding_logo_color_mode'] ?? 'logomark';
 	$color    = str_replace( '#', '', $icon_color );
 	$width    = 'logomark' === $variant ? 300 : 600;


### PR DESCRIPTION
Add 'logomark' as an additional 'branding_logo_color_mode ' setting, with some added custom logic for the design arguments for this type (custom width and template).

Defaults to use the logomark design.