### PR TITLE
Change tax calculation for fee

### DIFF
--- a/classes/requests/helpers/class-dintero-checkout-cart.php
+++ b/classes/requests/helpers/class-dintero-checkout-cart.php
@@ -170,7 +170,7 @@ class Dintero_Checkout_Cart extends Dintero_Checkout_Helper_Base {
 			'quantity'    => 1,
 			'amount'      => self::format_number( $fee->amount + $fee->tax ),
 			'vat_amount'  => self::format_number( $fee->tax ),
-			'vat'         => empty( floatval( $fee->amount + $fee->tax ) ) ? 0 : self::format_number( $fee->tax / ( $fee->amount + $fee->tax ) ),
+			'vat'         => empty( floatval( $fee->amount ) ) ? 0 : self::format_number( $fee->tax / $fee->amount ),
 		);
 	}
 

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -325,7 +325,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			'quantity'    => 1,
 			'amount'      => $amount,
 			'vat_amount'  => $vat_amount,
-			'vat'         => $fee_total <= 0 ? 0 : $fee_total_tax / $fee_total,
+			'vat'         => $fee_total <= 0 ? 0 : self::format_number( $fee_total_tax / $fee_total ),
 		);
 	}
 

--- a/classes/requests/helpers/class-dintero-checkout-order.php
+++ b/classes/requests/helpers/class-dintero-checkout-order.php
@@ -325,7 +325,7 @@ class Dintero_Checkout_Order extends Dintero_Checkout_Helper_Base {
 			'quantity'    => 1,
 			'amount'      => $amount,
 			'vat_amount'  => $vat_amount,
-			'vat'         => $amount <= 0 ? 0 : $vat_amount / $amount,
+			'vat'         => $fee_total <= 0 ? 0 : $fee_total_tax / $fee_total,
 		);
 	}
 


### PR DESCRIPTION
Order/cart lines for WooCommerce fees were sending an incorrect vat value to Dintero. The field was being computed by dividing the tax by the gross amount instead of by the net amount, and in the order helper the format_number scaling was missing entirely.

For a 100 kr fee with 25 kr VAT (25% rate), the request body looked like:

{ "id": "100.00 kr fee", "amount": 12500, "vat_amount": 2500, "vat": 0.2 }
…which Dintero Backoffice rendered literally as 0.2 % on the VAT column, even though the amount and vat_amount were correct. Captures, refunds and payments still worked, but the displayed VAT rate for fee lines was wrong in the Dintero portal.

The bug was reproducible with fee created in pay for order and with fee plugin Payment Gateway Based Fees and Discounts for WooCommerce.