### PR TITLE
Clarify order note when Dintero reports the order as already captured

### DIFF
--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -156,7 +156,7 @@ class Dintero_Checkout_Order_Management {
 				);
 
 			} else {
-				$note = __( 'The Dintero order has been captured (no amount returned).', 'dintero-checkout-for-woocommerce' );
+				$note = __( 'The Dintero order has been captured.', 'dintero-checkout-for-woocommerce' );
 			}
 		}
 

--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -156,13 +156,13 @@ class Dintero_Checkout_Order_Management {
 				);
 
 			} else {
-				$note = __( 'The Dintero order has been captured.', 'dintero-checkout-for-woocommerce' );
+				$note = __( 'The Dintero order has been captured (no amount returned).', 'dintero-checkout-for-woocommerce' );
 			}
 		}
 
 		if ( ! isset( $note ) ) {
 			// Dintero will capture the order immediately for some payment methods (e.g., Swish).
-			$note = __( 'The Dintero order has been captured.', 'dintero-checkout-for-woocommerce' );
+			$note = __( 'The Dintero order is already marked as captured at Dintero. No capture request was sent.', 'dintero-checkout-for-woocommerce' );
 		}
 
 		$order->add_order_note( $note );


### PR DESCRIPTION
When `capture_order()` runs and Dintero already reports the order as `CAPTURED`, the plugin skips the API call and writes an order note. The previous wording was close to the note used after a normal capture, making it hard to tell the two cases apart.