### PR TITLE
Prevent fatal error when the stored debug log is not an array

### DIFF
--- a/.changelogs/2026-08-02-logger-array-slice-fatal
+++ b/.changelogs/2026-08-02-logger-array-slice-fatal
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed a critical error that could occur when attempting to parse the plugin log.

--- a/classes/class-dintero-checkout-logger.php
+++ b/classes/class-dintero-checkout-logger.php
@@ -141,9 +141,20 @@ class Dintero_Checkout_Logger {
 			$logs = json_decode( $logs );
 		}
 
+		// The option may hold an empty string or malformed JSON, in which case we start the log over.
+		if ( ! is_array( $logs ) ) {
+			$logs = array();
+		}
+
 		$logs   = array_slice( $logs, -14 );
 		$logs[] = $data;
-		$logs   = wp_json_encode( $logs );
-		update_option( 'krokedil_debuglog_dintero_checkout', $logs );
+
+		$encoded = wp_json_encode( $logs );
+		if ( false === $encoded ) {
+			// Storing the failed encode would leave the option unreadable for every later request.
+			return;
+		}
+
+		update_option( 'krokedil_debuglog_dintero_checkout', $encoded );
 	}
 }


### PR DESCRIPTION
`get_option( 'krokedil_debuglog_dintero_checkout' )` was passed straight to array_slice(). When the option held an empty string or malformed JSON the !empty() guard skipped json_decode(), and array_slice() raised a TypeError, taking down any request that logged a non-2xx API response.

The option could reach that state on its own: wp_json_encode() returns false when a log entry cannot be encoded, and that false was stored unchecked, leaving an empty option value that made every later failed request fatal.

Coerce the decoded value to an array, and skip the write when the encode fails so the existing log survives.

https://app.clickup.com/t/2423261/869e11423