### PR TITLE
Fix capture order notes amount fomatting

### DIFF
--- a/classes/class-dintero-checkout-order-management.php
+++ b/classes/class-dintero-checkout-order-management.php
@@ -146,8 +146,8 @@ class Dintero_Checkout_Order_Management {
 
 				$note = sprintf(
 					// translators: the amount, the currency.
-					__( 'The Dintero order has been captured. Captured amount: %1$.2f %2$s.', 'dintero-checkout-for-woocommerce' ),
-					substr_replace( $amount, wc_get_price_decimal_separator(), -2, 0 ),
+					__( 'The Dintero order has been captured. Captured amount: %1$s %2$s.', 'dintero-checkout-for-woocommerce' ),
+					number_format( $amount / 100, 2, wc_get_price_decimal_separator(), '' ),
 					$response['currency']
 				);
 


### PR DESCRIPTION
Fixes issue where the order note's "capture amount" after capture would display an incorrectly rounded price.