### PR TITLE
Fix: express checkout ignores the separate billing/shipping setting on address callback

### DIFF
--- a/.changelogs/2026-08-26-express-separate-shipping-address
+++ b/.changelogs/2026-08-26-express-separate-shipping-address
@@ -1,4 +1,4 @@
 Type: Fix
 Needs Documentation: no
 
-Fixed the express checkout accepting a differing billing and shipping address from Dintero's address callback (e.g. Apple Pay/Google Pay) even when the "Allow different billing and shipping address" setting was disabled. The session update now ships to the billing address in that case, matching what the checkout form already displays.
+Fixed the express checkout accepting a differing billing and shipping address from Dintero's address callback even when the "Allow different billing and shipping address" setting was disabled.

--- a/.changelogs/2026-08-26-express-separate-shipping-address
+++ b/.changelogs/2026-08-26-express-separate-shipping-address
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed the express checkout accepting a differing billing and shipping address from Dintero's address callback (e.g. Apple Pay/Google Pay) even when the "Allow different billing and shipping address" setting was disabled. The session update now ships to the billing address in that case, matching what the checkout form already displays.

--- a/classes/class-dintero-checkout-assets.php
+++ b/classes/class-dintero-checkout-assets.php
@@ -219,7 +219,7 @@ class Dintero_Checkout_Assets {
 				'verifyOrderTotalURL'                  => WC_AJAX::get_endpoint( 'dintero_verify_order_total' ),
 				'verifyOrderTotalNonce'                => wp_create_nonce( 'dintero_verify_order_total' ),
 				'verifyOrderTotalError'                => __( 'The cart was modified. Please try again.', 'dintero-checkout-for-woocommerce' ),
-				'allowDifferentBillingShippingAddress' => 'yes' === ( $settings['express_allow_different_billing_shipping_address'] ?? 'no' ) ? true : false,
+				'allowDifferentBillingShippingAddress' => dwc_allow_separate_shipping_address( $settings ),
 				'woocommerceShipToDestination'         => get_option( 'woocommerce_ship_to_destination' ),
 				'checkout_flow'                        => $settings['checkout_flow'] ?? 'express_popout',
 				'update_order_review_url'              => WC_AJAX::get_endpoint( 'update_order_review' ),

--- a/classes/requests/post/class-dintero-checkout-create-session.php
+++ b/classes/requests/post/class-dintero-checkout-create-session.php
@@ -68,7 +68,6 @@ class Dintero_Checkout_Create_Session extends Dintero_Checkout_Request_Post {
 			$customer_type = 'b2bc' === $customer_type ? array( 'b2c', 'b2b' ) : array( $customer_type );
 			$body['configuration']['allow_different_billing_shipping_address'] = $customer_type;
 		} elseif ( $is_express_session ) {
-			// Explicitly clear the merchant's Dintero profile default so a disabled setting can't inherit an enabled profile configuration.
 			$body['configuration']['allow_different_billing_shipping_address'] = array();
 		}
 

--- a/classes/requests/post/class-dintero-checkout-create-session.php
+++ b/classes/requests/post/class-dintero-checkout-create-session.php
@@ -60,18 +60,16 @@ class Dintero_Checkout_Create_Session extends Dintero_Checkout_Request_Post {
 			'profile_id' => $this->settings['profile_id'],
 		);
 
-		// 'billing' => Default to customer billing address
-		// 'shipping' => Default to customer shipping address
-		// 'billing_only' => Force shipping to the customer billing address only.
-		$shipping_destination = get_option( 'woocommerce_ship_to_destination' );
+		// Set if express or not. For order-pay, we default to redirect flow.
+		$is_express_session = ! is_wc_endpoint_url( 'order-pay' ) && $this->is_express() && $this->is_embedded();
 
-		$separate_shipping = wc_string_to_bool( $this->settings['express_allow_different_billing_shipping_address'] ?? 'no' );
-		if ( 'billing_only' !== $shipping_destination && $separate_shipping ) {
-			$customer_type = $this->settings['express_customer_type'];
+		if ( dwc_allow_separate_shipping_address( $this->settings ) ) {
+			$customer_type = $this->settings['express_customer_type'] ?? 'b2bc';
 			$customer_type = 'b2bc' === $customer_type ? array( 'b2c', 'b2b' ) : array( $customer_type );
 			$body['configuration']['allow_different_billing_shipping_address'] = $customer_type;
-
-			// By default this configuration is an empty array, therefore, we don't have to set it if $separate_shipping is set to false.
+		} elseif ( $is_express_session ) {
+			// Explicitly clear the merchant's Dintero profile default so a disabled setting can't inherit an enabled profile configuration.
+			$body['configuration']['allow_different_billing_shipping_address'] = array();
 		}
 
 		$billing_address = $helper->get_billing_address();
@@ -88,8 +86,7 @@ class Dintero_Checkout_Create_Session extends Dintero_Checkout_Request_Post {
 			$body['url']['callback_url'] = Dintero_Checkout_Callback::callback_url();
 		}
 
-		// Set if express or not. For order-pay, we default to redirect flow.
-		if ( ! is_wc_endpoint_url( 'order-pay' ) && $this->is_express() && $this->is_embedded() ) {
+		if ( $is_express_session ) {
 			$this->add_express_object( $body );
 		}
 

--- a/classes/requests/put/class-dintero-checkout-update-checkout-session.php
+++ b/classes/requests/put/class-dintero-checkout-update-checkout-session.php
@@ -87,6 +87,17 @@ class Dintero_Checkout_Update_Checkout_Session extends Dintero_Checkout_Request_
 				$callback_shipping = $helper->get_shipping_address();
 			}
 
+			// If separate billing/shipping addresses are not allowed, ship to billing — the checkout form already does this (dintero-checkout-express.js), so echo it back here too rather than trust the client-supplied callback data.
+			if ( ! empty( $callback_shipping ) && ! dwc_allow_separate_shipping_address( $this->settings ) ) {
+				foreach ( array( 'organization_number', 'business_name' ) as $key ) {
+					if ( empty( $callback_billing[ $key ] ) && ! empty( $callback_shipping[ $key ] ) ) {
+						$callback_billing[ $key ] = $callback_shipping[ $key ];
+					}
+				}
+
+				$callback_shipping = $callback_billing;
+			}
+
 			if ( ! empty( $callback_billing ) ) {
 				$body['order']['billing_address'] = $callback_billing;
 			}

--- a/classes/requests/put/class-dintero-checkout-update-checkout-session.php
+++ b/classes/requests/put/class-dintero-checkout-update-checkout-session.php
@@ -87,8 +87,8 @@ class Dintero_Checkout_Update_Checkout_Session extends Dintero_Checkout_Request_
 				$callback_shipping = $helper->get_shipping_address();
 			}
 
-			// If separate billing/shipping addresses are not allowed, ship to billing — the checkout form already does this (dintero-checkout-express.js), so echo it back here too rather than trust the client-supplied callback data.
-			if ( ! empty( $callback_shipping ) && ! dwc_allow_separate_shipping_address( $this->settings ) ) {
+			// If separate billing/shipping addresses are not allowed, ship to billing — the checkout form already does this (dintero-checkout-express.js), so echo it back here too rather than trust the client-supplied callback data. Gated on the billing address, not the shipping one: a callback carrying only a billing address must still overwrite a differing shipping address that Dintero kept from an earlier event.
+			if ( ! empty( $callback_billing ) && ! dwc_allow_separate_shipping_address( $this->settings ) ) {
 				foreach ( array( 'organization_number', 'business_name' ) as $key ) {
 					if ( empty( $callback_billing[ $key ] ) && ! empty( $callback_shipping[ $key ] ) ) {
 						$callback_billing[ $key ] = $callback_shipping[ $key ];

--- a/classes/requests/put/class-dintero-checkout-update-checkout-session.php
+++ b/classes/requests/put/class-dintero-checkout-update-checkout-session.php
@@ -87,7 +87,8 @@ class Dintero_Checkout_Update_Checkout_Session extends Dintero_Checkout_Request_
 				$callback_shipping = $helper->get_shipping_address();
 			}
 
-			// If separate billing/shipping addresses are not allowed, ship to billing — the checkout form already does this (dintero-checkout-express.js), so echo it back here too rather than trust the client-supplied callback data. Gated on the billing address, not the shipping one: a callback carrying only a billing address must still overwrite a differing shipping address that Dintero kept from an earlier event.
+			// Ship to billing when separate addresses are not allowed, same as the checkout form does.
+			// Gated on billing so a billing-only callback still overwrites a stale shipping address.
 			if ( ! empty( $callback_billing ) && ! dwc_allow_separate_shipping_address( $this->settings ) ) {
 				foreach ( array( 'organization_number', 'business_name' ) as $key ) {
 					if ( empty( $callback_billing[ $key ] ) && ! empty( $callback_shipping[ $key ] ) ) {

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -526,9 +526,6 @@ function dwc_is_popout( $settings ) {
 /**
  * Whether separate billing and shipping addresses are allowed.
  *
- * Mirrors the same rule enforced client-side by the express checkout script
- * (assets/js/dintero-checkout-express.js) — keep both in sync.
- *
  * @param array|null $settings The Dintero Checkout plugin settings. Defaults to the stored option.
  * @return bool
  */

--- a/includes/dintero-checkout-functions.php
+++ b/includes/dintero-checkout-functions.php
@@ -524,6 +524,24 @@ function dwc_is_popout( $settings ) {
 }
 
 /**
+ * Whether separate billing and shipping addresses are allowed.
+ *
+ * Mirrors the same rule enforced client-side by the express checkout script
+ * (assets/js/dintero-checkout-express.js) — keep both in sync.
+ *
+ * @param array|null $settings The Dintero Checkout plugin settings. Defaults to the stored option.
+ * @return bool
+ */
+function dwc_allow_separate_shipping_address( $settings = null ) {
+	if ( null === $settings ) {
+		$settings = get_option( 'woocommerce_dintero_checkout_settings' );
+	}
+
+	return ! wc_ship_to_billing_address_only()
+		&& wc_string_to_bool( $settings['express_allow_different_billing_shipping_address'] ?? 'no' );
+}
+
+/**
  * Whether we can update the checkout.
  *
  * @return bool


### PR DESCRIPTION
https://app.clickup.com/t/2423261/869ep3na0

## Summary
- Ticket: #869ep3na0
- The address-callback PUT to Dintero echoed the wallet-supplied billing/shipping addresses verbatim, so when "Allow different billing and shipping address" was off, Dintero ended up with a differing shipping address while WooCommerce (and its own form fields) recorded billing only. The session update now collapses shipping into billing server-side in that case, matching what the checkout form already does.
- The create-session request now explicitly sends an empty `configuration.allow_different_billing_shipping_address` array for express sessions when the setting is off, instead of omitting the key — previously an omitted key silently inherited whatever the merchant's Dintero session profile had configured.